### PR TITLE
Makes hubble-ui working with ipv6

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1339,9 +1339,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.11.0.tgz",
-      "integrity": "sha512-1DQG9rNgn1fNpfStCBnvErGMcuF29ixGuQAjh3CVPLCFVsQCtNQjbSOIEV7XV18YEa2fj2hLU52TmJMSII0Kzw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.11.1.tgz",
+      "integrity": "sha512-0A4nwErxzJiGt3WYMR6rvcQF46hFz04b6uCmW7Kuj+Cl0zwe7KKxeMiqbZDtHPOq1CcOHOIcKNWCacUKL5CdxQ==",
       "requires": {
         "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
@@ -1355,6 +1355,7 @@
         "jsonpath-plus": "^0.19.0",
         "openid-client": "2.5.0",
         "request": "^2.88.0",
+        "rfc4648": "^1.3.0",
         "shelljs": "^0.8.2",
         "tslib": "^1.9.3",
         "underscore": "^1.9.1",
@@ -1362,9 +1363,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-          "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+          "version": "10.17.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.16.tgz",
+          "integrity": "sha512-A4283YSA1OmnIivcpy/4nN86YlnKRiQp8PYwI2KdPCONEBN093QTb0gCtERtkLyVNGKKIGazTZ2nAmVzQU51zA=="
         }
       }
     },
@@ -11384,6 +11385,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rfc4648": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.3.0.tgz",
+      "integrity": "sha512-x36K12jOflpm1V8QjPq3I+pt7Z1xzeZIjiC8J2Oxd7bE1efTrOG241DTYVJByP/SxR9jl1t7iZqYxDX864jgBQ=="
     },
     "rimraf": {
       "version": "2.4.5",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
-    "@kubernetes/client-node": "0.11.0",
+    "@kubernetes/client-node": "0.11.1",
     "@sentry/node": "5.11.2",
     "apollo-server-caching": "0.5.1",
     "apollo-server-express": "2.9.16",

--- a/server/src/dbHubble.ts
+++ b/server/src/dbHubble.ts
@@ -241,16 +241,23 @@ export class DatabaseHubble implements IDatabase {
           `Found 1 hubble client in ${Date.now() - start}ms`
         );
       } else {
-        dns.resolve4(hubbleService || "hubble-grpc", (err, addresses) => {
+        const options = {
+          hints: dns.ADDRCONFIG,
+          all: true,
+        };
+        dns.lookup(hubbleService || "hubble-grpc", options, (err, addresses: dns.LookupAddress[]) => {
           if (err) {
             context.logger.error(err);
             return reject(err);
           }
+          const ipAdresses = addresses.map(
+            addr => (addr.family === 6 ? `[${addr.address}]` : addr.address)
+          );
           resolve(
-            addresses.map(
-              address =>
+            ipAdresses.map(
+              ip =>
                 new ObserverClient(
-                  `${address}:${hubblePort}`,
+                  `${ip}:${hubblePort}`,
                   grpc.credentials.createInsecure()
                 )
             )


### PR DESCRIPTION
## Context

Currently the ipv6 is broken for multiple reasons:
1. The kubernetes-client needs at least 0.11.1 to construct a correct URI with ipv6
see https://github.com/kubernetes-client/javascript/issues/380
2.  dns.resolve4 is used in [dbHubble.ts:244](https://github.com/cilium/hubble-ui/blob/15e8cd01287b0ef26079d7746885322813b6ea12/server/src/dbHubble.ts#L244)
3. If the kubernetes URI contains an ipv6 plus the 443 port the request will fail to verify the TLS
see issue https://github.com/request/request/issues/3274)

## Scope

This PR address the 2 first points, as the third still need to be fixed in request