### PR TITLE
Patch request to workaround request/request#3274

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json package.json
 RUN apt-get update \
  && apt-get install -y wget \
  && apt-get install -y unzip \
+ && apt-get install -y patch \
  && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip \
  && unzip protoc-3.9.1-linux-x86_64.zip \
  && mv /bin/protoc /usr/bin \
@@ -23,6 +24,10 @@ COPY server/package-lock.json server/package-lock.json
 
 # install all dependencies
 RUN npm run install:all
+
+# Fix TLS issue with IPv6
+COPY patches/ patches/
+RUN patch -p1 < patches/request_issue3274.patch
 
 COPY hubble/ hubble/
 COPY server/ server/

--- a/patches/request_issue3274.patch
+++ b/patches/request_issue3274.patch
@@ -1,0 +1,17 @@
+diff --git a/server/node_modules/request/request.js b/server/node_modules/request/request.js
+index 198b760..59f5d4d 100644
+--- a/server/node_modules/request/request.js
++++ b/server/node_modules/request/request.js
+@@ -288,13 +288,6 @@ Request.prototype.init = function (options) {
+   if (!self.hasHeader('host')) {
+     var hostHeaderName = self.originalHostHeaderName || 'host'
+     self.setHeader(hostHeaderName, self.uri.host)
+-    // Drop :port suffix from Host header if known protocol.
+-    if (self.uri.port) {
+-      if ((self.uri.port === '80' && self.uri.protocol === 'http:') ||
+-          (self.uri.port === '443' && self.uri.protocol === 'https:')) {
+-        self.setHeader(hostHeaderName, self.uri.hostname)
+-      }
+-    }
+     self.setHost = true
+   }


### PR DESCRIPTION
Following https://github.com/cilium/hubble-ui/pull/7

Adds a patch for request to workaround an issue with TLS and IPv6
see request/request#3274

This can be removed once the patch is merged upsteam.
