### PR TITLE
useForceUpdate hook fixed

### DIFF
--- a/client/src/hooks/useForceUpdate.ts
+++ b/client/src/hooks/useForceUpdate.ts
@@ -15,10 +15,10 @@ import { useCallback, useReducer } from "react";
 
 type VoidFunction = () => void;
 
-const reducer = (state: boolean, _action: null): boolean => !state;
+const reducer = (state: number, _action: null): number => (state + 1) % 0xffffff;
 
 export const useForceUpdate = (): VoidFunction => {
-  const [, dispatch] = useReducer(reducer, true);
+  const [, dispatch] = useReducer(reducer, 0);
   const memoizedDispatch = useCallback((): void => {
     dispatch(null);
   }, [dispatch]);


### PR DESCRIPTION
Hi,
I used this kind of hook useForceUpdate, but after one month I found the next error.
https://monosnap.com/file/4Wvg626bqImtDHx3sAy9EpM5OB0P4Y

I cant found minimal code for reproducing this error because simple cases worked without any errors. Full code who reproducing that error:
https://codesandbox.io/s/wonderful-star-e50rl

Possible fix:
```typescript
const reducer = (state: number, _action: null): number => (state + 1) % 0xffffff;
```
https://github.com/betula/lamp-luwak/blob/6e8d704ee425ff18d4eaaf36a48ba97bad6498f3/src/useForceUpdate.ts#L5
The error was disappeared after that fix.
https://monosnap.com/file/83MRDHxOEHEgUCyhrEW0es73GYFHlv

But very interested, when todo list has 3 lines, is ok worked without some error, only with even count of a todo list item.