### PR TITLE
feat: initial code for testing most of the Row component (FlowsTable)

### DIFF
--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
-import { act, React, render } from '@test-utils';
-import api from '~/api';
+import { act, React, render } from '~/testing';
 import { App } from '~/components/App';
+import api from '~/api';
 
 jest.mock('~/api');
 

--- a/client/src/components/App/index.tsx
+++ b/client/src/components/App/index.tsx
@@ -50,7 +50,6 @@ export const AppComponent: FunctionComponent<AppProps> = observer(props => {
 
   useEffect(() => {
     api.v1.getNamespaces().then((nss: Array<string>) => {
-      console.log('in getNamespaces');
       store.setNamespaces(nss);
     });
   }, []);

--- a/client/src/components/FlowsTable/Row.tsx
+++ b/client/src/components/FlowsTable/Row.tsx
@@ -1,0 +1,53 @@
+import React, { memo, useCallback } from 'react';
+import classnames from 'classnames';
+
+import { useFlowTimestamp } from './hooks/useFlowTimestamp';
+import { Flow } from '~/domain/flows';
+
+import css from './styles.scss';
+
+export interface RowProps {
+  flow: Flow;
+  selected: boolean;
+  onSelect: (flow: Flow) => void;
+  tsUpdateDelay: number;
+}
+
+export const Row = memo<RowProps>(function FlowsTableRow(props) {
+  const { flow } = props;
+  const ts = flow.millisecondsTimestamp;
+
+  const onClick = useCallback(() => props.onSelect(flow), []);
+  const timestamp = useFlowTimestamp(ts, props.tsUpdateDelay);
+
+  const sourceAppName = flow.sourceAppName ?? 'No app name';
+  const destinationAppName = flow.destinationAppName ?? 'No app name';
+
+  const sourceNamespace = flow.sourceNamespace ? (
+    <i>{flow.sourceNamespace}</i>
+  ) : (
+    ''
+  );
+  const destinationNamespace = flow.destinationNamespace ? (
+    <i>{flow.destinationNamespace}</i>
+  ) : (
+    ''
+  );
+
+  // prettier-ignore
+  const sourceTitle = <>{sourceAppName} {sourceNamespace}</>;
+  // prettier-ignore
+  const destinationTitle = <>{destinationAppName} {destinationNamespace}</>;
+
+  const className = classnames({ [css.selected]: props.selected });
+
+  return (
+    <tr className={className} onClick={onClick}>
+      <td>{sourceTitle}</td>
+      <td>{destinationTitle}</td>
+      <td>{flow.destinationPort}</td>
+      <td>{flow.verdictLabel}</td>
+      <td title={flow.isoTimestamp || undefined}>{timestamp}</td>
+    </tr>
+  );
+});

--- a/client/src/components/FlowsTable/__tests__/Row.test.tsx
+++ b/client/src/components/FlowsTable/__tests__/Row.test.tsx
@@ -49,42 +49,59 @@ const runInteractionTests = (
   });
 };
 
-const runVisualTests = (container: HTMLElement, exps: Expectations) => {
-  const sourceTitle = container!.querySelector('tr > td');
-  const destTitle = container!.querySelector('tr > td:nth-child(2)');
-  const destPort = container!.querySelector('tr > td:nth-child(3)');
-  const verdictLabel = container!.querySelector('tr > td:nth-child(4)');
+const runAppearanceTests = (
+  container: HTMLElement,
+  exps: Expectations,
+  selected: boolean,
+) => {
+  const tr = container!.querySelector('tr')!;
+
+  const sourceTitle = tr.querySelector('td');
+  const destTitle = tr.querySelector('td:nth-child(2)');
+  const destPort = tr.querySelector('td:nth-child(3)');
+  const verdictLabel = tr.querySelector('td:nth-child(4)');
 
   expect(sourceTitle!.textContent!.trim()).toBe(exps.sourceTitle);
   expect(destTitle!.textContent!.trim()).toBe(exps.destTitle);
   expect(destPort!.textContent).toBe(String(exps.destPort));
   expect(verdictLabel!.textContent).toBe(exps.verdict);
+
+  if (selected) {
+    expect(tr.className).toContain('selected');
+  } else {
+    expect(tr.className).not.toContain('selected');
+  }
 };
 
 const runTest = (ntest: number, hf: HubbleFlow, exps: Expectations) => {
   const flow = new Flow(hf);
-  const onSelect = jest.fn((f: Flow) => void 0);
+  const isSelected = [false, true];
 
-  describe(`FlowsTable: Row / test ${ntest}`, () => {
-    let container: HTMLElement | null = null;
+  isSelected.forEach(selected => {
+    const onSelect = jest.fn((f: Flow) => void 0);
+    const selectedStr = selected ? 'selected' : 'not-selected';
 
-    beforeEach(() => {
-      container = renderRow(
-        <Row
-          flow={flow}
-          selected={false}
-          onSelect={onSelect}
-          tsUpdateDelay={1000}
-        ></Row>,
-      );
-    });
+    describe(`FlowsTable: Row (${selectedStr}) / test ${ntest}`, () => {
+      let container: HTMLElement | null = null;
 
-    test(`visual`, () => {
-      runVisualTests(container!, exps);
-    });
+      beforeEach(() => {
+        container = renderRow(
+          <Row
+            flow={flow}
+            selected={selected}
+            onSelect={onSelect}
+            tsUpdateDelay={1000}
+          ></Row>,
+        );
+      });
 
-    test(`interactions`, () => {
-      runInteractionTests(container!, flow, onSelect);
+      test(`visual`, () => {
+        runAppearanceTests(container!, exps, selected);
+      });
+
+      test(`interactions`, () => {
+        runInteractionTests(container!, flow, onSelect);
+      });
     });
   });
 };

--- a/client/src/components/FlowsTable/__tests__/Row.test.tsx
+++ b/client/src/components/FlowsTable/__tests__/Row.test.tsx
@@ -1,0 +1,142 @@
+import _ from 'lodash';
+
+import { act, React, render, data, fireEvent } from '~/testing';
+import { Row } from '~/components/FlowsTable/Row';
+
+import { Flow } from '~/domain/flows';
+import { HubbleFlow } from '~/domain/hubble';
+
+interface Expectations {
+  sourceTitle: string;
+  destTitle: string;
+  destPort: number;
+  verdict: string;
+}
+
+const renderRow = (elem: React.ReactElement<any>): HTMLElement => {
+  let container: HTMLElement | null = null;
+
+  act(() => {
+    const component = (
+      <table>
+        <tbody>{elem}</tbody>
+      </table>
+    );
+
+    container = render(component).container;
+  });
+
+  return container!;
+};
+
+const runInteractionTests = (
+  container: HTMLElement,
+  flow: Flow,
+  onSelect: jest.Mock<void>,
+) => {
+  const tr = container.querySelector('tr')!;
+  fireEvent.click(tr);
+
+  const tds = container.querySelectorAll('tr > td');
+  tds.forEach(td => {
+    fireEvent.click(td);
+  });
+
+  expect(onSelect.mock.calls.length).toBe(1 + tds.length);
+
+  _.range(1 + tds.length).forEach((idx: number) => {
+    expect(onSelect.mock.calls[idx][0]).toBe(flow);
+  });
+};
+
+const runVisualTests = (container: HTMLElement, exps: Expectations) => {
+  const sourceTitle = container!.querySelector('tr > td');
+  const destTitle = container!.querySelector('tr > td:nth-child(2)');
+  const destPort = container!.querySelector('tr > td:nth-child(3)');
+  const verdictLabel = container!.querySelector('tr > td:nth-child(4)');
+
+  expect(sourceTitle!.textContent!.trim()).toBe(exps.sourceTitle);
+  expect(destTitle!.textContent!.trim()).toBe(exps.destTitle);
+  expect(destPort!.textContent).toBe(String(exps.destPort));
+  expect(verdictLabel!.textContent).toBe(exps.verdict);
+};
+
+const runTest = (ntest: number, hf: HubbleFlow, exps: Expectations) => {
+  const flow = new Flow(hf);
+  const onSelect = jest.fn((f: Flow) => void 0);
+
+  describe(`FlowsTable: Row / test ${ntest}`, () => {
+    let container: HTMLElement | null = null;
+
+    beforeEach(() => {
+      container = renderRow(
+        <Row
+          flow={flow}
+          selected={false}
+          onSelect={onSelect}
+          tsUpdateDelay={1000}
+        ></Row>,
+      );
+    });
+
+    test(`visual`, () => {
+      runVisualTests(container!, exps);
+    });
+
+    test(`interactions`, () => {
+      runInteractionTests(container!, flow, onSelect);
+    });
+  });
+};
+
+runTest(1, data.flows.hubbleOne, {
+  sourceTitle: 'Sender SenderNs',
+  destTitle: 'Receiver ReceiverNs',
+  destPort: 80,
+  verdict: 'forwarded',
+});
+
+runTest(2, data.flows.hubbleNoSourceName, {
+  sourceTitle: 'No app name SenderNs',
+  destTitle: 'Receiver ReceiverNs',
+  destPort: 80,
+  verdict: 'forwarded',
+});
+
+runTest(3, data.flows.hubbleNoDstName, {
+  sourceTitle: 'Sender SenderNs',
+  destTitle: 'No app name ReceiverNs',
+  destPort: 80,
+  verdict: 'forwarded',
+});
+
+runTest(4, data.flows.hubbleNoSourceNamespace, {
+  sourceTitle: 'Sender',
+  destTitle: 'Receiver ReceiverNs',
+  destPort: 80,
+  verdict: 'forwarded',
+});
+
+runTest(5, data.flows.hubbleNoDstNamespace, {
+  sourceTitle: 'Sender SenderNs',
+  destTitle: 'Receiver',
+  destPort: 80,
+  verdict: 'forwarded',
+});
+
+runTest(6, data.flows.hubbleDropped, {
+  sourceTitle: 'Sender SenderNs',
+  destTitle: 'Receiver ReceiverNs',
+  destPort: 80,
+  verdict: 'dropped',
+});
+
+runTest(7, data.flows.hubbleVerdictUnknown, {
+  sourceTitle: 'Sender SenderNs',
+  destTitle: 'Receiver ReceiverNs',
+  destPort: 80,
+  verdict: 'unknown',
+});
+
+// TODO: test className on tr
+// TODO: test useFlowTimestamp

--- a/client/src/components/FlowsTable/index.tsx
+++ b/client/src/components/FlowsTable/index.tsx
@@ -1,9 +1,11 @@
-import classnames from 'classnames';
 import React, { memo, useCallback } from 'react';
-import { Flow } from '~/domain/flows';
-import { FlowsTableColumn } from './constants';
-import { useFlowTimestamp } from './hooks/useFlowTimestamp';
+
+import { Row } from './Row';
 import { useScroll } from './hooks/useScroll';
+
+import { FlowsTableColumn } from './constants';
+import { Flow } from '~/domain/flows';
+
 import css from './styles.scss';
 
 export const DEFAULT_TS_UPDATE_DELAY = 2500;
@@ -56,7 +58,7 @@ export interface BodyProps {
   tsUpdateDelay: number;
 }
 
-const Body = memo<BodyProps>(function FlowsTableBody(props) {
+export const Body = memo<BodyProps>(function FlowsTableBody(props) {
   const onSelectFlow = useCallback(
     (flow: Flow) => {
       props.onSelectFlow && props.onSelectFlow(flow);
@@ -76,52 +78,5 @@ const Body = memo<BodyProps>(function FlowsTableBody(props) {
         />
       ))}
     </tbody>
-  );
-});
-
-export interface RowProps {
-  flow: Flow;
-  selected: boolean;
-  onSelect: (flow: Flow) => void;
-  tsUpdateDelay: number;
-}
-
-const Row = memo<RowProps>(function FlowsTableRow(props) {
-  const { flow } = props;
-
-  const ts = flow.millisecondsTimestamp;
-
-  const onClick = useCallback(() => props.onSelect(flow), []);
-  const timestamp = useFlowTimestamp(ts, props.tsUpdateDelay);
-
-  const sourceAppName = flow.sourceAppName ?? 'No app name';
-  const destinationAppName = flow.destinationAppName ?? 'No app name';
-
-  const sourceNamespace = flow.sourceNamespace ? (
-    <i>{flow.sourceNamespace}</i>
-  ) : (
-    ''
-  );
-  const destinationNamespace = flow.destinationNamespace ? (
-    <i>{flow.destinationNamespace}</i>
-  ) : (
-    ''
-  );
-
-  // prettier-ignore
-  const sourceTitle = <>{sourceAppName} {sourceNamespace}</>;
-  // prettier-ignore
-  const destinationTitle = <>{destinationAppName} {destinationNamespace}</>;
-
-  const className = classnames({ [css.selected]: props.selected });
-
-  return (
-    <tr className={className} onClick={onClick}>
-      <td>{sourceTitle}</td>
-      <td>{destinationTitle}</td>
-      <td>{flow.destinationPort}</td>
-      <td>{flow.verdictLabel}</td>
-      <td title={flow.isoTimestamp || undefined}>{timestamp}</td>
-    </tr>
   );
 });

--- a/client/src/testing/data/flows.ts
+++ b/client/src/testing/data/flows.ts
@@ -1,0 +1,77 @@
+import { Flow } from '~/domain/flows';
+import { HubbleFlow, Verdict, FlowType, Endpoint } from '~/domain/hubble';
+
+export const hubbleOne: HubbleFlow = {
+  verdict: Verdict.Forwarded,
+  dropReason: 0,
+  l4: {
+    tcp: {
+      destinationPort: 80,
+      sourcePort: 56789,
+    },
+  },
+  source: {
+    id: 0,
+    identity: 0,
+    labelsList: ['app=Sender', 'namespace=SenderNs'],
+    namespace: 'kube-system',
+    podName: `sender-a1b2c3`,
+  },
+  destination: {
+    id: 1,
+    identity: 1,
+    labelsList: ['app=Receiver', 'namespace=ReceiverNs'],
+    namespace: 'kube-system',
+    podName: `receiver-d4e5f6`,
+  },
+  sourceNamesList: [],
+  destinationNamesList: [],
+  nodeName: 'TestNode',
+  reply: false,
+  summary: '',
+  type: FlowType.L34,
+};
+
+export const hubbleNoSourceName: HubbleFlow = {
+  ...hubbleOne,
+  source: {
+    ...hubbleOne.source,
+    labelsList: ['namespace=SenderNs'],
+  } as Endpoint,
+};
+
+export const hubbleNoDstName: HubbleFlow = {
+  ...hubbleOne,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: ['namespace=ReceiverNs'],
+  } as Endpoint,
+};
+
+export const hubbleNoSourceNamespace: HubbleFlow = {
+  ...hubbleOne,
+  source: {
+    ...hubbleOne.source,
+    labelsList: ['app=Sender'],
+  } as Endpoint,
+};
+
+export const hubbleNoDstNamespace: HubbleFlow = {
+  ...hubbleOne,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: ['app=Receiver'],
+  } as Endpoint,
+};
+
+export const hubbleDropped: HubbleFlow = {
+  ...hubbleOne,
+  verdict: Verdict.Dropped,
+};
+
+export const hubbleVerdictUnknown: HubbleFlow = {
+  ...hubbleOne,
+  verdict: Verdict.Unknown,
+};
+
+export const normalOne: Flow = new Flow(hubbleOne);

--- a/client/src/testing/data/index.ts
+++ b/client/src/testing/data/index.ts
@@ -1,0 +1,3 @@
+import * as flows from './flows';
+
+export { flows };

--- a/client/src/testing/index.tsx
+++ b/client/src/testing/index.tsx
@@ -1,14 +1,20 @@
-import { render } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 import React, { FunctionComponent } from 'react';
+
 import { StoreProvider } from '~/store';
+import * as data from './data';
 
 const AllProviders: FunctionComponent = ({ children }) => {
   return <StoreProvider>{children}</StoreProvider>;
 };
 
-const customRender: typeof render = (async (ui: any, options: any) => {
+const customRender = (
+  ui: React.ReactElement<any>,
+  options?: any,
+): RenderResult => {
   return render(ui, { wrapper: AllProviders, ...options });
-}) as any;
+};
 
 export * from '@testing-library/react';
 export { React, customRender as render };
+export { data };

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,7 +10,6 @@
     "paths": {
       "~/*": ["./*"],
       "~common/*": ["../../common/src/*"],
-      "@test-utils": ["./utils/@test-utils"]
     },
     "typeRoots": ["./node_modules/@types"],
     "types": ["node", "jest"],


### PR DESCRIPTION
This PR suggests few changes on testing utils
- `@test-utils` moved to `~/testing`
- `~/testing` directory fulfilled with examples of testing (mock) data for flows
- `Row.tsx` is now separate component:
  - It's simplier to read coverage report
- `Row.test.tsx` performs **not complete** testing on `Row` component:
  - Timestamp field and css styling not tested yet (WIP)
  - Each test performs whole bunch of interaction tests as well as visual tests, so that for any combination of input props we can be sure that there is no regress on other parts (interactions/styles/etc)

Signed-off-by: Renat Tuktarov renat@isovalent.com