### PR TITLE
feat: external (world) cards now have id set to its domain names

### DIFF
--- a/client/src/components/EndpointCardHeader/index.tsx
+++ b/client/src/components/EndpointCardHeader/index.tsx
@@ -38,7 +38,9 @@ export const EndpointCardHeader: FunctionComponent<LayerProps> = props => {
         </div>
         <div className={css.headings}>
           <div className={css.title}>{card.caption}</div>
-          <div className={css.subtitle}>{card.id}</div>
+          {card.isWorld && card.domain && (
+            <div className={css.subtitle}>{card.domain}</div>
+          )}
         </div>
         {false && (
           <div className={css.settingsIcon}>

--- a/client/src/domain/service-card.ts
+++ b/client/src/domain/service-card.ts
@@ -59,12 +59,19 @@ export class ServiceCard<InteractionsExt = {}> {
     });
   }
 
-  public get id() {
+  public get id(): string {
     return this.service.id;
   }
 
   public get caption(): string {
     return this.appLabel || 'Unknown App';
+  }
+
+  public get domain(): string | null {
+    if (this.service.dnsNames.length === 0) return null;
+
+    // TODO: better algorithm for getting domain name?
+    return this.service.dnsNames[0];
   }
 
   public get labels(): Array<KV> {
@@ -99,6 +106,7 @@ export class ServiceCard<InteractionsExt = {}> {
     // );
   }
 
+  // TODO: this is wrong determination of isDNS, isnt it?
   public get isDNS(): boolean {
     return this.service.dnsNames.length > 0;
   }


### PR DESCRIPTION
* FEAT: card header fixed to show proper service name (hide id, show id in case if it is world card)