### PR TITLE
add base Docker image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/library/node:14.4.0-buster-slim
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false


### PR DESCRIPTION
Using a base docker image that we control we can upgrade it while
keeping reproducibility of builds for the top level Docker image.

Instead of using 'stretch' we should use the 'buster' debian version as
'scretch' is reaching EOL and 'buster' is the stable version.

Signed-off-by: André Martins <andre@cilium.io>