### PR TITLE
Use Alpine as the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,31 @@
-FROM quay.io/cilium/hubble-ui-base:2020-06-19-7b4c868d6b7d
-
+# Use Debian as the build image until we figure out how to install grpc-tools on
+# Alpine.
+FROM node:14.4.0-slim
 ENV CI true
-
-# add non-root user
-RUN useradd -u 1001 hubble-ui
-
-# install global dependencies
 COPY package.json package.json
+COPY cilium/ cilium/
+COPY client/ client/
+COPY server/ server/
+RUN apt-get update && apt-get install -y make patch python \
+ && npm run install:all \
+ && npm run build \
+ && npm run test
 
-RUN apt-get update \
- && apt-get install -y wget \
- && apt-get install -y unzip \
- && apt-get install -y patch \
- && wget https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip \
- && unzip protoc-3.9.1-linux-x86_64.zip \
- && mv /bin/protoc /usr/bin \
- && mv include/google /usr/include
-
-# install client dependencies
-COPY client/package.json client/package.json
-COPY client/package-lock.json client/package-lock.json
-
-# install server dependencies
+# Use Alpine as the runtime image to avoid dealing with security vulnerabilities
+# on Debian-based image.
+FROM node:14.4.0-alpine3.12
+WORKDIR /workspace
+COPY package.json package.json
 COPY server/package.json server/package.json
 COPY server/package-lock.json server/package-lock.json
-
-# install all dependencies
-RUN npm run install:all
-
-# Fix TLS issue with IPv6
-COPY patches/ patches/
-RUN patch -p1 < patches/request_issue3274.patch
-
-COPY cilium/ cilium/
-COPY server/ server/
-
-# run test and build server
-RUN npm run build:server \
-    && npm run test:server
-
-ARG NODE_ENV=production
-COPY client/ client/
-RUN npm run test:client \
- && npm run build:client \
- && npm run install:server
-
-FROM quay.io/cilium/hubble-ui-base:2020-06-19-7b4c868d6b7d
-WORKDIR /workspace
-COPY --from=0 /server/node_modules server/node_modules
-COPY --from=0 /server/package.json server/package.json
 COPY --from=0 /server/build server/build
 COPY --from=0 /client/build client/build
 COPY --from=0 /client/index.html client/index.html
-COPY --from=0 /etc/passwd /etc/passwd
+COPY patches/ patches/
+RUN adduser --system --uid 1001 hubble-ui \
+ && npm run install:prod \
+ && apk add --no-cache patch \
+ && patch -p1 < patches/request_issue3274.patch
 WORKDIR /workspace/server
 USER 1001
 EXPOSE 12000

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "install:client": "cd client; npm install",
     "install:server": "cd server; npm install",
     "install:all": "npm run install:client; npm run install:server",
+    "install:prod": "cd server; npm install --production",
     "start:client": "cd client; npm start",
     "start:server": "cd server; npm start",
     "build:client": "cd client; npm run build",


### PR DESCRIPTION
I couldn't make grpc-tool work on Alpine. For now continue using Debian
for building, but use Alpine as the runtime image to avoid dealing with
security vulnerabilities.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>