### PR TITLE
feat: do local data (flows / services / layout) filtering not to drop entire store

### DIFF
--- a/client/src/api/general/event-stream.ts
+++ b/client/src/api/general/event-stream.ts
@@ -53,7 +53,7 @@ export interface DataFilters {
   namespace: string;
   verdict?: Verdict | null;
   httpStatus?: string | null;
-  filters: FlowsFilterEntry[];
+  filters?: FlowsFilterEntry[];
   skipHost?: boolean;
   skipKubeDns?: boolean;
 }

--- a/client/src/api/grpc/event-stream.ts
+++ b/client/src/api/grpc/event-stream.ts
@@ -118,7 +118,7 @@ export class EventStream extends EventEmitter<EventStreamHandlers>
       wlDstFilter.addVerdict(dataHelpers.verdictToPb(filters.verdict));
     }
 
-    filters?.filters.forEach(filter => {
+    filters?.filters?.forEach(filter => {
       switch (filter.direction) {
         case FlowsFilterDirection.Both: {
           switch (filter.kind) {

--- a/client/src/components/App/DataManager.ts
+++ b/client/src/components/App/DataManager.ts
@@ -1,0 +1,183 @@
+import { useState, useCallback } from 'react';
+
+import { API } from '~/api/general';
+import * as mockData from '~/api/__mocks__/data';
+import { GeneralStreamEventKind } from '~/api/general/stream';
+
+import { HubbleFlow } from '~/domain/hubble';
+import { Filters } from '~/domain/filtering';
+import { EventEmitter } from '~/utils/emitter';
+import {
+  EventParamsSet,
+  EventKind as EventStreamEventKind,
+  NamespaceChange,
+  ServiceChange,
+  ServiceLinkChange,
+  IEventStream,
+  DataFilters,
+} from '~/api/general/event-stream';
+
+import { Store, StoreFrame } from '~/store';
+
+export enum EventKind {
+  StreamError = 'stream-error',
+  StreamEnd = 'stream-end',
+  FlowsDiff = 'flows-diff',
+  StoreMocked = 'store-mocked',
+}
+
+type Events = {
+  [EventKind.StreamError]: () => void;
+  [EventKind.StreamEnd]: () => void;
+  [EventKind.FlowsDiff]: (diff: number) => void;
+  [EventKind.StoreMocked]: () => void;
+};
+
+interface StreamDescriptor {
+  stream: IEventStream;
+  dataFilters?: DataFilters;
+}
+
+export class DataManager extends EventEmitter<Events> {
+  private api: API;
+  private store: Store;
+
+  private initialStream: StreamDescriptor | null = null;
+  private mainStream: StreamDescriptor | null = null;
+  private filteringStream: StreamDescriptor | null = null;
+
+  constructor(api: API, store: Store) {
+    super();
+
+    this.api = api;
+    this.store = store;
+  }
+
+  public setupMock() {
+    this.store.setup(mockData);
+    this.store.controls.setCurrentNamespace(mockData.selectedNamespace);
+    this.store.controls.setCrossNamespaceActivity(true);
+
+    this.emit(EventKind.StoreMocked);
+  }
+
+  public setupMainStream(namespace: string) {
+    const store = this.store;
+
+    const streamParams = { ...store.controls.mainFilters, namespace };
+    const stream = this.api.v1.getEventStream(EventParamsSet.All, streamParams);
+
+    this.setupGeneralEventHandlers(stream);
+    this.setupNamespaceEventHandlers(stream);
+    this.setupServicesEventHandlers(stream, store.mainFrame);
+
+    this.mainStream = { stream, dataFilters: streamParams };
+  }
+
+  public dropMainStream() {
+    if (this.mainStream == null) return;
+
+    this.mainStream.stream.stop();
+    this.offAllStreamEvents(this.mainStream.stream);
+    this.mainStream = null;
+  }
+
+  public setupFilteringFrame(namespace: string) {
+    const store = this.store;
+    const streamParams = { ...store.controls.dataFilters, namespace };
+
+    const stream = this.api.v1.getEventStream(EventParamsSet.All, streamParams);
+    const secondaryFrame = store.currentFrame.filter(streamParams as Filters);
+    store.pushFrame(secondaryFrame);
+
+    this.setupGeneralEventHandlers(stream);
+    this.setupNamespaceEventHandlers(stream);
+    this.setupServicesEventHandlers(stream, secondaryFrame);
+
+    this.filteringStream = { stream, dataFilters: streamParams };
+  }
+
+  public dropFilteringFrame() {
+    if (this.filteringStream == null) return;
+
+    this.filteringStream.stream.stop();
+    this.offAllStreamEvents(this.filteringStream.stream);
+    this.filteringStream = null;
+    this.store.squashFrames();
+  }
+
+  public setupInitialStream() {
+    const stream = this.api.v1.getEventStream(EventParamsSet.Namespaces);
+
+    this.setupGeneralEventHandlers(stream);
+    this.setupNamespaceEventHandlers(stream);
+
+    this.initialStream = { stream };
+  }
+
+  public dropInitialStream() {
+    if (this.initialStream == null) return;
+
+    this.initialStream.stream.stop();
+    this.offAllStreamEvents(this.initialStream.stream);
+    this.initialStream = null;
+  }
+
+  public resetNamespace(namespace: string) {
+    if (this.mainStream) {
+      this.dropMainStream();
+      this.store.flush();
+    }
+
+    this.dropInitialStream();
+    this.setupMainStream(namespace);
+  }
+
+  private setupNamespaceEventHandlers(stream: IEventStream) {
+    stream.on(EventStreamEventKind.Namespace, (nsChange: NamespaceChange) => {
+      this.store.applyNamespaceChange(nsChange.name, nsChange.change);
+    });
+  }
+
+  private setupServicesEventHandlers(stream: IEventStream, frame: StoreFrame) {
+    stream.on(EventStreamEventKind.Service, (svcChange: ServiceChange) => {
+      frame.applyServiceChange(svcChange.service, svcChange.change);
+    });
+
+    stream.on(EventStreamEventKind.Flows, (flows: HubbleFlow[]) => {
+      const { flowsDiffCount } = frame.addFlows(flows);
+
+      this.emit(EventKind.FlowsDiff, flowsDiffCount);
+    });
+
+    stream.on(EventStreamEventKind.ServiceLink, (link: ServiceLinkChange) => {
+      frame.applyServiceLinkChange(link.serviceLink, link.change);
+    });
+  }
+
+  private setupGeneralEventHandlers(stream: IEventStream) {
+    stream.on(GeneralStreamEventKind.Error, () => {
+      this.emit(EventKind.StreamError);
+    });
+
+    stream.on(GeneralStreamEventKind.End, () => {
+      this.emit(EventKind.StreamEnd);
+    });
+  }
+
+  private offAllStreamEvents(stream: IEventStream) {
+    stream.offAllEvents();
+  }
+
+  public get flowsDelay(): number | undefined {
+    return this.mainStream?.stream.flowsDelay;
+  }
+
+  public get currentNamespace(): string | undefined {
+    return this.mainStream?.dataFilters?.namespace;
+  }
+
+  public get hasFilteringStream(): boolean {
+    return this.filteringStream != null;
+  }
+}

--- a/client/src/domain/filtering/index.ts
+++ b/client/src/domain/filtering/index.ts
@@ -1,0 +1,184 @@
+import {
+  FlowsFilterEntry,
+  FlowsFilterKind,
+  FlowsFilterDirection,
+  HubbleFlow,
+  Flow,
+  Verdict,
+} from '~/domain/flows';
+
+import { Link } from '~/domain/service-map';
+
+export interface Filters {
+  namespace?: string | null;
+  verdict?: Verdict | null;
+  httpStatus?: string | null;
+  filters?: FlowsFilterEntry[];
+}
+
+export const filterFlow = (flow: Flow, filters: Filters): boolean => {
+  if (filters.namespace != null) {
+    if (
+      flow.sourceNamespace !== filters.namespace &&
+      flow.destinationNamespace !== filters.namespace
+    )
+      return false;
+  }
+
+  if (filters.verdict != null && flow.verdict !== filters.verdict) {
+    return false;
+  }
+
+  if (filters.httpStatus != null) {
+    if (`${flow.httpStatus}` !== filters.httpStatus) return false;
+  }
+
+  let ok = true;
+  filters.filters?.forEach((ff: FlowsFilterEntry) => {
+    const passed = filterFlowUsingBasicEntry(flow, ff);
+
+    ok = ok && passed;
+  });
+
+  return ok;
+};
+
+export const filterLink = (link: Link, filters: Filters): boolean => {
+  if (filters.verdict != null && !link.verdicts.has(filters.verdict)) {
+    return false;
+  }
+
+  let ok = true;
+  filters.filters?.forEach((ff: FlowsFilterEntry) => {
+    const passed = filterLinkUsingBasicEntry(link, ff);
+
+    ok = ok && passed;
+  });
+
+  return ok;
+};
+
+export const filterLinkUsingBasicEntry = (
+  l: Link,
+  e: FlowsFilterEntry,
+): boolean => {
+  const sourceIdentityMatch = l.sourceId === e.query;
+  const destIdentityMatch = l.destinationId === e.query;
+
+  switch (e.direction) {
+    case FlowsFilterDirection.Both: {
+      switch (e.kind) {
+        case FlowsFilterKind.Identity: {
+          if (!sourceIdentityMatch && !destIdentityMatch) return false;
+          break;
+        }
+      }
+      break;
+    }
+    case FlowsFilterDirection.To: {
+      switch (e.kind) {
+        case FlowsFilterKind.Identity: {
+          if (!destIdentityMatch) return false;
+          break;
+        }
+      }
+      break;
+    }
+    case FlowsFilterDirection.From: {
+      switch (e.kind) {
+        case FlowsFilterKind.Identity: {
+          if (!sourceIdentityMatch) return false;
+          break;
+        }
+      }
+      break;
+    }
+  }
+
+  return true;
+};
+
+export const filterFlowUsingBasicEntry = (
+  f: Flow,
+  e: FlowsFilterEntry,
+): boolean => {
+  const [k, v] = e.labelKeyValue;
+  const sourceLabelMatch = !!f.sourceLabels.find(l => l.key === k);
+  const destLabelMatch = !!f.destinationLabels.find(l => l.key === k);
+
+  const sourceDnsMatch = f.sourceNamesList.includes(e.query);
+  const destDnsMatch = f.destinationNamesList.includes(e.query);
+
+  const sourceIdentityMatch = f.sourceIdentity === +e.query;
+  const destIdentityMatch = f.destinationIdentity === +e.query;
+
+  switch (e.direction) {
+    case FlowsFilterDirection.Both: {
+      switch (e.kind) {
+        case FlowsFilterKind.Label: {
+          if (!sourceLabelMatch && !destLabelMatch) return false;
+          break;
+        }
+        case FlowsFilterKind.Ip: {
+          if (f.sourceIp !== e.query && f.destinationIp !== e.query) {
+            return false;
+          }
+          break;
+        }
+        case FlowsFilterKind.Dns: {
+          if (!sourceDnsMatch && !destDnsMatch) return false;
+          break;
+        }
+        case FlowsFilterKind.Identity: {
+          if (!sourceIdentityMatch && !destIdentityMatch) return false;
+          break;
+        }
+      }
+      break;
+    }
+    case FlowsFilterDirection.From: {
+      switch (e.kind) {
+        case FlowsFilterKind.Label: {
+          if (!sourceLabelMatch) return false;
+          break;
+        }
+        case FlowsFilterKind.Ip: {
+          if (f.sourceIp !== e.query) return false;
+          break;
+        }
+        case FlowsFilterKind.Dns: {
+          if (!sourceDnsMatch) return false;
+          break;
+        }
+        case FlowsFilterKind.Identity: {
+          if (!sourceIdentityMatch) return false;
+          break;
+        }
+      }
+      break;
+    }
+    case FlowsFilterDirection.To: {
+      switch (e.kind) {
+        case FlowsFilterKind.Label: {
+          if (!destLabelMatch) return false;
+          break;
+        }
+        case FlowsFilterKind.Ip: {
+          if (f.destinationIp !== e.query) return false;
+          break;
+        }
+        case FlowsFilterKind.Dns: {
+          if (!destDnsMatch) return false;
+          break;
+        }
+        case FlowsFilterKind.Identity: {
+          if (!destIdentityMatch) return false;
+          break;
+        }
+      }
+      break;
+    }
+  }
+
+  return true;
+};

--- a/client/src/domain/flows/flows-filter-entry.ts
+++ b/client/src/domain/flows/flows-filter-entry.ts
@@ -147,4 +147,10 @@ export class FlowsFilterEntry {
   public get isIdentity(): boolean {
     return this.kind === FlowsFilterKind.Identity;
   }
+
+  public get labelKeyValue(): [string, string] {
+    const [key, ...rest] = this.query.split('=');
+
+    return [key, rest.join('=')];
+  }
 }

--- a/client/src/domain/service-card.ts
+++ b/client/src/domain/service-card.ts
@@ -1,6 +1,9 @@
-import { Labels } from './labels';
+import _ from 'lodash';
+
+import { Service, Link, ApplicationKind, Interactions } from './service-map';
 import { KV } from './misc';
-import { ApplicationKind, Service } from './service-map';
+import { reserved } from './cilium';
+import { Labels } from './labels';
 
 // This entity maintains ONLY THE DATA of service card
 export class ServiceCard {
@@ -16,6 +19,27 @@ export class ServiceCard {
     return new ServiceCard(srvc);
   }
 
+  public clone(): ServiceCard {
+    return new ServiceCard(_.cloneDeep(this.service));
+  }
+  
+// <<<<<<< HEAD
+// =======
+
+//   public updateLinkEndpoint(link: Link) {
+//     const links = this.incidentInteractions.links || [];
+
+//     // TODO: do real actions
+//     links.push(link);
+
+//     this.incidentInteractions.links = links;
+//   }
+
+//   public get links(): Array<Link> {
+//     return this.incidentInteractions.links || [];
+//   }
+
+// >>>>>>> a1fd4c2... feat: do local data (flows / services / layout) filtering not to drop entire store
   public get appProtocol(): ApplicationKind | undefined {
     const appLbl = this.appLabel;
     if (appLbl == null) return undefined;

--- a/client/src/store/frame.ts
+++ b/client/src/store/frame.ts
@@ -1,0 +1,181 @@
+import _ from 'lodash';
+import { observable, action } from 'mobx';
+
+import InteractionStore from '~/store/stores/interaction';
+import LayoutStore from '~/store/stores/layout';
+import ServiceStore from '~/store/stores/service';
+import ControlStore from '~/store/stores/controls';
+
+import { Filters, filterFlow, filterLink } from '~/domain/filtering';
+import { Link, Service } from '~/domain/service-map';
+import { HubbleService, HubbleLink } from '~/domain/hubble';
+import { StateChange } from '~/domain/misc';
+import { ServiceCard } from '~/domain/service-card';
+import { Flow, FlowsFilterEntry, HubbleFlow, Verdict } from '~/domain/flows';
+import { Vec2 } from '~/domain/geometry';
+
+export class StoreFrame {
+  @observable
+  public controls: ControlStore;
+
+  @observable
+  public interactions: InteractionStore;
+
+  @observable
+  public services: ServiceStore;
+
+  @observable
+  public layout: LayoutStore;
+
+  constructor(
+    interactions: InteractionStore,
+    services: ServiceStore,
+    controls: ControlStore,
+  ) {
+    this.interactions = interactions;
+    this.services = services;
+    this.controls = controls;
+
+    this.layout = new LayoutStore(services, interactions, controls);
+  }
+
+  getServiceById(id: string) {
+    return this.services.byId(id);
+  }
+
+  @action.bound
+  applyServiceChange(svc: HubbleService, change: StateChange) {
+    this.services.applyServiceChange(svc, change);
+  }
+
+  @action.bound
+  addFlows(flows: HubbleFlow[]) {
+    return this.interactions.addFlows(flows);
+  }
+
+  @action.bound
+  applyServiceLinkChange(link: HubbleLink, change: StateChange) {
+    this.interactions.applyLinkChange(link, change);
+  }
+
+  @action.bound
+  setServices(services: HubbleService[]) {
+    this.services.set(services);
+  }
+
+  @action.bound
+  setControls(controls: ControlStore) {
+    this.controls = controls;
+  }
+
+  @action.bound
+  setHubbleLinks(links: HubbleLink[]) {
+    this.interactions.setHubbleLinks(links);
+  }
+
+  // @action.bound
+  // updateLinkEndpoints(links: HubbleLink[]) {
+  //   this.services.updateLinkEndpoints(links);
+  // }
+
+  @action.bound
+  setAccessPointCoords(apId: string, coords: Vec2) {
+    this.layout.setAccessPointCoords(apId, coords);
+  }
+
+  @action.bound
+  setActiveService(serviceId: string): boolean {
+    return this.services.setActive(serviceId);
+  }
+
+  @action.bound
+  toggleActiveService(serviceId: string): boolean {
+    return this.services.toggleActive(serviceId);
+  }
+
+  @action.bound
+  isCardActive(serviceId: string): boolean {
+    return this.services.isCardActive(serviceId);
+  }
+
+  @action.bound
+  moveServices(to: StoreFrame): number {
+    return this.services.moveTo(to.services);
+  }
+
+  @action.bound
+  moveServiceLinks(to: StoreFrame) {
+    return this.interactions.moveTo(to.interactions);
+  }
+
+  @action.bound
+  filter(filters: Filters): StoreFrame {
+    const services = new ServiceStore();
+    const interactions = new InteractionStore();
+    const flows: Flow[] = [];
+    const links: Link[] = [];
+
+    const allowedServiceIds: Set<string> = new Set();
+
+    // We can easily filter flows by filters as we have enough data for it in
+    // one place
+    const wasFlows = this.interactions.flows.length;
+    this.interactions.flows.forEach((f: Flow) => {
+      if (!filterFlow(f, filters)) return;
+
+      if (f.destinationIdentity != null) {
+        allowedServiceIds.add(`${f.destinationIdentity}`);
+      }
+
+      if (f.sourceIdentity != null) {
+        allowedServiceIds.add(`${f.sourceIdentity}`);
+      }
+
+      flows.push(f.clone());
+    });
+
+    const afterFilter = flows.length;
+    console.log(`filtering result: ${wasFlows}, afterFilter: ${afterFilter}`);
+    console.log(`allowedServiceIds: `, allowedServiceIds);
+
+    // Link doesnt have `namespace`, `httpStatus` and protcol information
+    // We have to filter it using non-direct criteria
+    this.interactions.links.forEach((l: Link) => {
+      if (!filterLink(l, filters)) return;
+
+      // TODO: check if such filtering is correct
+      const isLinkForPresentService =
+        allowedServiceIds.has(l.sourceId) ||
+        allowedServiceIds.has(l.destinationId);
+
+      if (!isLinkForPresentService) return;
+
+      links.push(_.cloneDeep(l));
+    });
+
+    this.services.cardsList.forEach((c: ServiceCard) => {
+      // TODO: is it required to additionaly check namespace / labels?
+      const isOk = allowedServiceIds.has(c.id);
+      if (!isOk) return;
+
+      if (this.services.isCardActive(c.id)) {
+        services.setActive(c.id);
+      }
+
+      services.addNewCard(c.clone());
+    });
+
+    interactions.setFlows(flows);
+    interactions.setLinks(links);
+
+    return new StoreFrame(interactions, services, this.controls);
+  }
+
+  clone() {
+    return new StoreFrame(
+      this.interactions.clone(),
+      this.services.clone(),
+      this.controls,
+    );
+  }
+}

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,4 +1,5 @@
 import { useStore, StoreProvider } from './hooks';
 import { Store } from './stores/main';
+import { StoreFrame } from './frame';
 
-export { useStore, StoreProvider, Store };
+export { useStore, StoreProvider, Store, StoreFrame };

--- a/client/src/store/stores/layout.ts
+++ b/client/src/store/stores/layout.ts
@@ -60,13 +60,6 @@ export default class LayoutStore {
 
     this.cardDimensions = new Map();
     this.accessPointsCoords = new Map();
-
-    reaction(
-      () => this.services.cardsList,
-      () => {
-        this.initUnitializedCards();
-      },
-    );
   }
 
   static defaultCardDims(): WH {
@@ -82,6 +75,7 @@ export default class LayoutStore {
   @action.bound
   initUnitializedCards() {
     this.services.cardsList.forEach(card => {
+      console.log(`card: ${card.id}: `, this.cardDimensions.get(card.id));
       if (this.cardDimensions.has(card.id)) return;
 
       this.cardDimensions.set(card.id, LayoutStore.defaultCardDims());
@@ -100,7 +94,7 @@ export default class LayoutStore {
 
   @action.bound
   setCardHeight(id: string, height: number) {
-    const dim = this.cardDimensions.get(id) || LayoutStore.defaultCardDims();
+    const dim = this.getCardDimensions(id);
     const updated = Object.assign({}, dim, { h: height });
 
     this.cardDimensions.set(id, updated);
@@ -357,6 +351,10 @@ export default class LayoutStore {
     return placement;
   }
 
+  public getCardDimensions(id: string): WH {
+    return this.cardDimensions.get(id) ?? LayoutStore.defaultCardDims();
+  }
+
   private alignColumns(
     cardsColumns: CardsColumns,
     kinds: PlacementKind[],
@@ -382,7 +380,7 @@ export default class LayoutStore {
         offset.y = 0;
 
         column.forEach((meta: PlacementMeta, ri: number) => {
-          const cardWH = this.cardDimensions.get(meta.card.id);
+          const cardWH = this.getCardDimensions(meta.card.id);
           if (cardWH == null) return;
 
           const geomtry = XYWH.fromArgs(offset.x, offset.y, cardWH.w, cardWH.h);

--- a/client/src/store/stores/route.ts
+++ b/client/src/store/stores/route.ts
@@ -150,7 +150,6 @@ export default class RouteStore {
     const query = qs.length > 0 ? '?' + qs : '';
     const hash = transformed.hash.length > 0 ? '#' + this.hash : '';
 
-    console.log(`gotoFn: `, path, query, hash);
     this.history.navigate(`/${path}${query}${hash}`);
   }
 


### PR DESCRIPTION
* FEAT: store now contains `StoreFrames` which represent layers of data
* FEAT: two getters are maintained inside `Store`: `currentFrame` and `mainFrame`
* FEAT: advanced functions to `clone` / `move` / `merge` data to/from different stores and entities
* FEAT: functions to make local filtration on data (`~/domain/filtering` module)
* FEAT: huge amount of control logic has been moved from App root to App `DataManager` which is a new component doing all whats needed on store frames, streams and events handlers
* FEAT: the data is squashed into main frame when there is no need to maintain secondary layer of data
* FIX: `Flow` class was fixed not to use generic `object-hash` hashing and use domain-specific data to generate flow id (I have a talk with @gandro about that). I strongly recommend not to use object-hash and remove it from project dependencies.

A certain attention should be paid to `~/domain/filtering` in this code as **this code is not covered by tests** (TODO). An error in filtering module can lead to critical UI/UX errors.
