### PR TITLE
fix: bunch of fixes

### DIFF
--- a/client/src/api/grpc/event-stream.ts
+++ b/client/src/api/grpc/event-stream.ts
@@ -16,7 +16,7 @@ import { Flow, FlowFilter, EventTypeFilter } from '~/proto/flow/flow_pb';
 import { HubbleFlow } from '~/domain/hubble';
 import { FlowsFilterDirection, FlowsFilterKind } from '~/domain/flows';
 import { CiliumEventTypes } from '~/domain/cilium';
-import { ReservedLabel } from '~/domain/labels';
+import { ReservedLabel, SpecialLabel } from '~/domain/labels';
 import * as dataHelpers from '~/domain/helpers';
 
 import { EventEmitter } from '~/utils/emitter';
@@ -231,8 +231,8 @@ export class EventStream extends EventEmitter<EventStreamHandlers>
         new FlowFilter(),
         new FlowFilter(),
       ];
-      blSrcKubeDnsFilter.addSourceLabel('k8s:k8s-app=kube-dns');
-      blDstKubeDnsFilter.addDestinationLabel('k8s:k8s-app=kube-dns');
+      blSrcKubeDnsFilter.addSourceLabel(SpecialLabel.KubeDNS);
+      blDstKubeDnsFilter.addDestinationLabel(SpecialLabel.KubeDNS);
       blDstKubeDnsFilter.addDestinationPort('53');
       blFilters.push(blSrcKubeDnsFilter, blDstKubeDnsFilter);
     }

--- a/client/src/components/App/DataManager.ts
+++ b/client/src/components/App/DataManager.ts
@@ -3,7 +3,7 @@ import * as mockData from '~/api/__mocks__/data';
 import { GeneralStreamEventKind } from '~/api/general/stream';
 
 import { HubbleFlow } from '~/domain/hubble';
-import { Filters } from '~/domain/filtering';
+import { Filters, areFiltersEqual } from '~/domain/filtering';
 import { EventEmitter } from '~/utils/emitter';
 import {
   EventParamsSet,
@@ -184,5 +184,24 @@ export class DataManager extends EventEmitter<Events> {
 
   public get hasFilteringStream(): boolean {
     return this.filteringStream != null;
+  }
+
+  public get filtersChanged(): boolean {
+    if (this.filteringStream != null && this.filteringStream.dataFilters) {
+      return !areFiltersEqual(
+        this.store.controls.dataFilters,
+        this.filteringStream.dataFilters,
+      );
+    }
+
+    if (this.mainStream != null && this.mainStream.dataFilters) {
+      // debugger;
+      return !areFiltersEqual(
+        this.store.controls.dataFilters,
+        this.mainStream.dataFilters,
+      );
+    }
+
+    return false;
   }
 }

--- a/client/src/components/App/index.tsx
+++ b/client/src/components/App/index.tsx
@@ -77,10 +77,12 @@ export const AppComponent: FunctionComponent<AppProps> = observer(props => {
         const { namespaces, currentNamespace } = store.controls;
         if (currentNamespace && namespaces.includes(currentNamespace)) return;
 
-        const message = `Namespace "${currentNamespace}" is still not observed. Keep waiting for the data`;
+        const message = `
+        Namespace "${currentNamespace}" is still not observed.
+        Keep waiting for the data.
+      `;
 
         notifier.showWarning(message, 5000, IconNames.SEARCH_AROUND);
-
         storage.deleteLastNamespace();
       }, 2000),
     );
@@ -100,13 +102,12 @@ export const AppComponent: FunctionComponent<AppProps> = observer(props => {
       dataManager.resetNamespace(newNamespace);
     }
 
+    const filtersChanged = dataManager.filtersChanged;
     if (dataManager.hasFilteringStream) {
       dataManager.dropFilteringFrame();
     }
 
-    const filtersNonNull = !store.controls.isDefault;
-
-    if (filtersNonNull) {
+    if (filtersChanged) {
       dataManager.setupFilteringFrame(store.controls.currentNamespace);
     }
 

--- a/client/src/components/EndpointCard/EndpointCardContent.tsx
+++ b/client/src/components/EndpointCard/EndpointCardContent.tsx
@@ -44,8 +44,6 @@ export const EndpointCardContent = memo(function EndpointCardContent(
       return;
     }
 
-    // console.log(`emitting connector coords from card: ${props.card.appLabel || props.card.id}`);
-    // console.log(`center getters: `, centerGetters);
     centerGetters.forEach((cg: CenterGetter, apId: string) => {
       const connectorCenter = centerGetters.get(apId)!();
       const relCoords = connectorCenter.sub(Vec2.fromXY(bbox));

--- a/client/src/domain/filtering/index.ts
+++ b/client/src/domain/filtering/index.ts
@@ -8,13 +8,45 @@ import {
 } from '~/domain/flows';
 
 import { Link, Service } from '~/domain/service-map';
+import { ServiceCard } from '~/domain/service-card';
 
 export interface Filters {
   namespace?: string | null;
   verdict?: Verdict | null;
   httpStatus?: string | null;
   filters?: FlowsFilterEntry[];
+  skipHost?: boolean;
+  skipKubeDns?: boolean;
 }
+
+export const areFiltersEqual = (a: Filters, b: Filters): boolean => {
+  if (
+    a.namespace != b.namespace ||
+    a.verdict != b.verdict ||
+    a.httpStatus != b.httpStatus ||
+    a.skipHost != b.skipHost ||
+    a.skipKubeDns != b.skipKubeDns
+  )
+    return false;
+
+  const aEntries = (a.filters || []).reduce((acc, f) => {
+    acc.add(f.toString());
+    return acc;
+  }, new Set());
+
+  const bEntries = (b.filters || []).reduce((acc, f) => {
+    acc.add(f.toString());
+    return acc;
+  }, new Set());
+
+  if (aEntries.size !== bEntries.size) return false;
+
+  for (const f of aEntries) {
+    if (!bEntries.has(f)) return false;
+  }
+
+  return true;
+};
 
 export const filterFlow = (flow: Flow, filters: Filters): boolean => {
   if (filters.namespace != null) {
@@ -58,10 +90,13 @@ export const filterLink = (link: Link, filters: Filters): boolean => {
   return ok;
 };
 
-export const filterService = (service: Service, filters: Filters): boolean => {
+export const filterService = (svc: ServiceCard, filters: Filters): boolean => {
+  if (filters.skipHost && svc.isHost) return false;
+  if (filters.skipKubeDns && svc.isKubeDNS) return false;
+
   let ok = true;
   filters.filters?.forEach((ff: FlowsFilterEntry) => {
-    const passed = filterServiceUsingBasicEntry(service, ff);
+    const passed = filterServiceUsingBasicEntry(svc.service, ff);
 
     ok = ok && passed;
   });

--- a/client/src/domain/geometry/vec2.ts
+++ b/client/src/domain/geometry/vec2.ts
@@ -29,6 +29,11 @@ export class Vec2 implements XY {
     return new Vec2(this.x + arg.x, this.y + arg.y);
   }
 
+  public addInPlace(arg: XY) {
+    this.x += arg.x;
+    this.y += arg.y;
+  }
+
   public mul(n: number): Vec2 {
     return new Vec2(this.x * n, this.y * n);
   }

--- a/client/src/domain/helpers/index.ts
+++ b/client/src/domain/helpers/index.ts
@@ -317,8 +317,3 @@ export const msToPbTimestamp = (ms: number): Time => {
 export const flowFromRelay = (hubbleFlow: HubbleFlow): Flow => {
   return new Flow(hubbleFlow);
 };
-
-export const linkFromRelay = (hubbleLink: HubbleLink): Link => {
-  const { verdict, ...props } = hubbleLink;
-  return { ...props, verdicts: new Set([verdict]) };
-};

--- a/client/src/domain/link.ts
+++ b/client/src/domain/link.ts
@@ -1,0 +1,49 @@
+import { HubbleLink, Verdict } from '~/domain/hubble';
+
+export class Link {
+  public verdicts: Set<Verdict> = new Set();
+
+  constructor(private ref: HubbleLink) {}
+
+  public clone(): Link {
+    const link = Link.fromHubbleLink(this.ref);
+    link.verdicts = new Set([...this.verdicts]);
+
+    return link;
+  }
+
+  public static fromHubbleLink(hl: HubbleLink): Link {
+    return new Link(hl);
+  }
+
+  public updateWithHubbleLink(hl: HubbleLink): Link {
+    const updated = this.clone();
+    updated.verdicts.add(hl.verdict);
+
+    return updated;
+  }
+
+  public get hubbleLink(): HubbleLink {
+    return this.ref;
+  }
+
+  public get id() {
+    return this.ref.id;
+  }
+
+  public get destinationId() {
+    return this.ref.destinationId;
+  }
+
+  public get sourceId() {
+    return this.ref.sourceId;
+  }
+
+  public get ipProtocol() {
+    return this.ref.ipProtocol;
+  }
+
+  public get destinationPort() {
+    return this.ref.destinationPort;
+  }
+}

--- a/client/src/domain/service-card.ts
+++ b/client/src/domain/service-card.ts
@@ -2,11 +2,13 @@ import _ from 'lodash';
 
 import { Service, ApplicationKind } from './service-map';
 import { KV } from './misc';
-import { Labels } from './labels';
+import { Labels, LabelsProps } from './labels';
 
 // This entity maintains ONLY THE DATA of service card
 export class ServiceCard {
   public static readonly AppLabel = 'k8s:app';
+
+  private _labelsProps: LabelsProps | null = null;
 
   public service: Service;
 
@@ -35,8 +37,16 @@ export class ServiceCard {
     return undefined;
   }
 
+  private get labelsProps(): LabelsProps {
+    if (this._labelsProps === null) {
+      this._labelsProps = Labels.detect(this.service.labels);
+    }
+
+    return this._labelsProps;
+  }
+
   public get appLabel(): string | null {
-    return Labels.findAppNameInLabels(this.service.labels);
+    return this.labelsProps.appName || null;
   }
 
   public get isCovalentRelated(): boolean {
@@ -75,19 +85,23 @@ export class ServiceCard {
   }
 
   public get isWorld(): boolean {
-    return Labels.isWorld(this.service.labels);
+    return this.labelsProps.isWorld;
   }
 
   public get isHost(): boolean {
-    return Labels.isHost(this.service.labels);
+    return this.labelsProps.isHost;
   }
 
   public get isInit(): boolean {
-    return Labels.isInit(this.service.labels);
+    return this.labelsProps.isInit;
   }
 
   public get isRemoteNode(): boolean {
-    return Labels.isRemoteNode(this.service.labels);
+    return this.labelsProps.isRemoteNode;
+  }
+
+  public get isKubeDNS(): boolean {
+    return this.labelsProps.isKubeDNS;
   }
 
   public get isCIDR(): boolean {

--- a/client/src/domain/service-map.ts
+++ b/client/src/domain/service-map.ts
@@ -6,11 +6,11 @@ import {
   HubbleLink,
 } from './hubble';
 
+import { Link } from './link';
+
 export type Service = HubbleService;
 
-export type Link = Omit<HubbleLink, 'verdict'> & {
-  verdicts: Set<Verdict>;
-};
+export { Link };
 
 export interface AccessPoint {
   id: string;

--- a/client/src/store/stores/controls.ts
+++ b/client/src/store/stores/controls.ts
@@ -3,6 +3,7 @@ import { action, observable, computed } from 'mobx';
 
 import { Flow, FlowsFilterEntry, FlowsFilterKind } from '~/domain/flows';
 import { Verdict } from '~/domain/hubble';
+import { Filters } from '~/domain/filtering';
 
 // This store maintains data that is configured by control interfaces
 export default class ControlStore {
@@ -126,7 +127,7 @@ export default class ControlStore {
   }
 
   @computed
-  get dataFilters() {
+  get dataFilters(): Filters {
     return {
       namespace: this.currentNamespace,
       verdict: this.verdict,

--- a/client/src/store/stores/interaction.ts
+++ b/client/src/store/stores/interaction.ts
@@ -6,7 +6,7 @@ import { Link, AccessPoints } from '~/domain/service-map';
 import { ids } from '~/domain/ids';
 import { HubbleLink } from '~/domain/hubble';
 import { StateChange } from '~/domain/misc';
-import { flowFromRelay, linkFromRelay } from '~/domain/helpers';
+import { flowFromRelay } from '~/domain/helpers';
 
 // { cardId -> { cardId -> { acessPointId : Link }  }
 export type ConnectionsMap = Map<string, Map<string, Map<string, Link>>>;
@@ -60,8 +60,10 @@ export default class InteractionStore {
   }
 
   @action.bound
-  setHubbleLinks(links: HubbleLink[]) {
-    links.forEach(this.addLink);
+  setHubbleLinks(hubbleLinks: HubbleLink[]) {
+    const links = hubbleLinks.map(Link.fromHubbleLink);
+
+    this.setLinks(links);
   }
 
   @action.bound
@@ -141,7 +143,7 @@ export default class InteractionStore {
   private addLink(hubbleLink: HubbleLink) {
     if (this.linksMap.has(hubbleLink.id)) return this.updateLink(hubbleLink);
 
-    this.links.push(linkFromRelay(hubbleLink));
+    this.links.push(Link.fromHubbleLink(hubbleLink));
   }
 
   @action.bound
@@ -168,10 +170,7 @@ export default class InteractionStore {
     if (idx === -1) return;
 
     const currentLink = this.links[idx];
-    const updatedLink: Link = {
-      ...currentLink,
-      verdicts: new Set([...currentLink.verdicts, hubbleLink.verdict]),
-    };
+    const updatedLink = currentLink.updateWithHubbleLink(hubbleLink);
 
     this.links.splice(idx, 1, updatedLink);
   }

--- a/client/src/store/stores/main.ts
+++ b/client/src/store/stores/main.ts
@@ -292,22 +292,16 @@ export class Store {
   }
 
   @action.bound
-  public toggleShowKubeDns(flush = true): boolean {
+  public toggleShowKubeDns(): boolean {
     const isActive = this.controls.toggleShowKubeDns();
-    if (flush) {
-      this.flush();
-    }
 
     storage.saveShowKubeDns(isActive);
     return isActive;
   }
 
   @action.bound
-  public toggleShowHost(flush = true): boolean {
+  public toggleShowHost(): boolean {
     const isActive = this.controls.toggleShowHost();
-    if (flush) {
-      this.flush();
-    }
 
     storage.saveShowHost(isActive);
     return isActive;
@@ -349,7 +343,7 @@ export class Store {
   private printMapData() {
     const data = {
       services: this.currentFrame.services.cardsList.map(c => c.service),
-      links: this.currentFrame.interactions.links,
+      links: this.currentFrame.interactions.links.map(l => l.hubbleLink),
     };
 
     console.log(JSON.stringify(data, null, 2));


### PR DESCRIPTION
* FEAT: `Link` now has its own wrapper around domain `HubbleLink` type
* FEAT: `Labels` in service are now effectively calculated and cached
* FIX: do not render the same card connector multiple times
* FIX: physical connectors middle point is now correctly calculated
* FIX: proper reaction to toggle showKubeDNS, showHost controls (do not flush the map)
* FIX: updating of start plate coords has been fixed (it was wrong in some margin cases)