### PR TITLE
fix: App-level clock synchronizer for updating row timestamp

### DIFF
--- a/client/src/components/App/index.tsx
+++ b/client/src/components/App/index.tsx
@@ -14,6 +14,8 @@ import { TopBar } from '~/components/TopBar';
 import {
   DetailsPanel,
   ResizeProps as DetailsResizeProps,
+  TickerEvents as DPTickerEvents,
+  DEFAULT_TS_UPDATE_DELAY,
 } from '~/components/DetailsPanel';
 import { Map } from '~/components/Map';
 import { LoadingOverlay } from '~/components/Misc/LoadingOverlay';
@@ -29,6 +31,7 @@ import { API } from '~/api/general';
 import * as storage from '~/storage/local';
 import { DataManager, EventKind as DataManagerEvents } from './DataManager';
 
+import { Ticker } from '~/utils/ticker';
 import { sizes } from '~/ui/vars';
 import css from './styles.scss';
 
@@ -49,6 +52,13 @@ export const AppComponent: FunctionComponent<AppProps> = observer(props => {
   const dataManager = useMemo(() => {
     return new DataManager(props.api, store);
   }, []);
+
+  const ticker = useMemo(() => {
+    const ticker = new Ticker<DPTickerEvents>();
+    ticker.start(DPTickerEvents.TimestampUpdate, DEFAULT_TS_UPDATE_DELAY);
+
+    return ticker;
+  }, [dataManager]);
 
   useEffect(() => {
     dataManager.on(DataManagerEvents.StreamError, () => {
@@ -213,7 +223,7 @@ export const AppComponent: FunctionComponent<AppProps> = observer(props => {
         selectedFlow={frame.controls.selectedTableFlow}
         onSelectFlow={frame.controls.selectTableFlow}
         onCloseSidebar={onCloseFlowsTableSidebar}
-        tsUpdateDelay={dataManager.flowsDelay}
+        ticker={ticker}
         onPanelResize={onPanelResize}
       />
     </div>

--- a/client/src/components/DetailsPanel/index.tsx
+++ b/client/src/components/DetailsPanel/index.tsx
@@ -7,13 +7,20 @@ import React, {
 } from 'react';
 
 import { DragPanel } from '~/components/DragPanel';
-import { FlowsTable, Props as FlowsTableProps } from '~/components/FlowsTable';
+import {
+  FlowsTable,
+  Props as FlowsTableProps,
+  TickerEvents,
+  DEFAULT_TS_UPDATE_DELAY,
+} from '~/components/FlowsTable';
 import { FlowsTableSidebar } from '~/components/FlowsTable/Sidebar';
 import { useFlowsTableColumns } from '~/components/FlowsTable/hooks/useColumns';
 
 import css from './styles.scss';
 import { LoadingOverlay } from '../Misc/LoadingOverlay';
 import { usePanelResize, ResizeProps } from './hooks/usePanelResize';
+
+export { DEFAULT_TS_UPDATE_DELAY, TickerEvents };
 
 interface SidebarProps {
   onCloseSidebar?: () => void;
@@ -68,7 +75,7 @@ export const DetailsPanelComponent = function (props: Props) {
             isVisibleColumn={flowsTableColumns.isVisibleColumn}
             selectedFlow={props.selectedFlow}
             onSelectFlow={props.onSelectFlow}
-            tsUpdateDelay={props.tsUpdateDelay}
+            ticker={props.ticker}
           />
         ) : (
           <LoadingOverlay text="Waiting for table data…" />

--- a/client/src/components/FlowsTable/Body.tsx
+++ b/client/src/components/FlowsTable/Body.tsx
@@ -2,13 +2,14 @@ import React, { memo, useCallback } from 'react';
 
 import { Row } from './Row';
 import { Flow } from '~/domain/flows';
-import { CommonProps } from './general';
+import { CommonProps, TickerEvents } from './general';
+import { Ticker } from '~/utils/ticker';
 
 export interface BodyProps extends CommonProps {
   flows: Flow[];
   selectedFlow: Flow | null;
   onSelectFlow?: (flow: Flow | null) => void;
-  tsUpdateDelay: number;
+  ticker: Ticker<TickerEvents>;
 }
 
 export const Body = memo<BodyProps>(function FlowsTableBody(props) {
@@ -28,7 +29,7 @@ export const Body = memo<BodyProps>(function FlowsTableBody(props) {
           isVisibleColumn={props.isVisibleColumn}
           selected={props.selectedFlow?.id === flow.id}
           onSelect={onSelectFlow}
-          tsUpdateDelay={props.tsUpdateDelay}
+          ticker={props.ticker}
         />
       ))}
     </tbody>

--- a/client/src/components/FlowsTable/Row.tsx
+++ b/client/src/components/FlowsTable/Row.tsx
@@ -1,9 +1,10 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import classnames from 'classnames';
 
 import { useWhenOccured } from './hooks/useWhenOccured';
 import { Flow } from '~/domain/flows';
-import { CommonProps } from './general';
+import { CommonProps, TickerEvents } from './general';
+import { Ticker } from '~/utils/ticker';
 
 import css from './styles.scss';
 
@@ -11,7 +12,7 @@ export interface RowProps extends CommonProps {
   flow: Flow;
   selected: boolean;
   onSelect: (flow: Flow) => void;
-  tsUpdateDelay: number;
+  ticker: Ticker<TickerEvents>;
 }
 
 export const Row = memo<RowProps>(function FlowsTableRow(props) {
@@ -19,7 +20,7 @@ export const Row = memo<RowProps>(function FlowsTableRow(props) {
   const ts = flow.millisecondsTimestamp;
 
   const onClick = useCallback(() => props.onSelect(flow), []);
-  const timestamp = useWhenOccured(ts, props.tsUpdateDelay);
+  const timestamp = useWhenOccured(props.ticker, ts);
 
   const sourceAppName = flow.sourceAppName ?? 'No app name';
   const destinationAppName = flow.destinationAppName ?? 'No app name';

--- a/client/src/components/FlowsTable/__tests__/Row.test.tsx
+++ b/client/src/components/FlowsTable/__tests__/Row.test.tsx
@@ -2,10 +2,15 @@ import _ from 'lodash';
 
 import { act, React, render, data, fireEvent } from '~/testing';
 import { Row } from '~/components/FlowsTable/Row';
+import {
+  TickerEvents,
+  DEFAULT_TS_UPDATE_DELAY,
+} from '~/components/DetailsPanel';
 
 import { Flow } from '~/domain/flows';
 import { HubbleFlow } from '~/domain/hubble';
 import { elapsedInWords } from '~/utils/time';
+import { Ticker } from '~/utils/ticker';
 
 const tsUpdateDelay = 5000;
 
@@ -96,6 +101,9 @@ const runTemporalTests = (container: HTMLElement, flow: Flow) => {
 const runTest = (ntest: number, hf: HubbleFlow, exps: Expectations) => {
   const flow = new Flow(hf);
   const isSelected = [false, true];
+  const ticker = new Ticker<TickerEvents>();
+
+  ticker.start(TickerEvents.TimestampUpdate, DEFAULT_TS_UPDATE_DELAY);
 
   isSelected.forEach(selected => {
     const onSelect = jest.fn((f: Flow) => void 0);
@@ -111,7 +119,7 @@ const runTest = (ntest: number, hf: HubbleFlow, exps: Expectations) => {
             isVisibleColumn={() => true}
             selected={selected}
             onSelect={onSelect}
-            tsUpdateDelay={tsUpdateDelay}
+            ticker={ticker}
           ></Row>,
         );
       });

--- a/client/src/components/FlowsTable/general.ts
+++ b/client/src/components/FlowsTable/general.ts
@@ -14,6 +14,10 @@ export enum FlowsTableColumn {
   Timestamp = 'Timestamp',
 }
 
+export enum TickerEvents {
+  TimestampUpdate = 'timestamp-update',
+}
+
 export type FlowsTableColumnKey = keyof typeof FlowsTableColumn;
 
 export const FLOWS_TABLE_COLUMNS = Object.keys(

--- a/client/src/components/FlowsTable/hooks/useWhenOccured.ts
+++ b/client/src/components/FlowsTable/hooks/useWhenOccured.ts
@@ -1,7 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import { elapsedInWords } from '~/utils/time';
+import { Ticker } from '~/utils/ticker';
 
-export function useWhenOccured(ms?: number | null, delayMs = 2500) {
+import { TickerEvents } from './../general';
+
+export function useWhenOccured(
+  ticker: Ticker<TickerEvents>,
+  ms?: number | null,
+) {
   const [elapsedWords, setWords] = useState('');
 
   const setter = useCallback(() => {
@@ -13,12 +19,12 @@ export function useWhenOccured(ms?: number | null, delayMs = 2500) {
 
   useEffect(() => {
     setter();
-    const interval = setInterval(setter, delayMs);
+    ticker.on(TickerEvents.TimestampUpdate, setter);
 
     return () => {
-      clearInterval(interval);
+      ticker.off(TickerEvents.TimestampUpdate, setter);
     };
-  }, []);
+  }, [ticker]);
 
   return elapsedWords;
 }

--- a/client/src/components/FlowsTable/index.tsx
+++ b/client/src/components/FlowsTable/index.tsx
@@ -4,24 +4,26 @@ import { Header } from './Header';
 import { Body } from './Body';
 
 import { Flow } from '~/domain/flows';
-import { CommonProps } from './general';
+import { CommonProps, TickerEvents } from './general';
 
 import { useScroll } from './hooks/useScroll';
 
+import { Ticker } from '~/utils/ticker';
 import css from './styles.scss';
+
 export const DEFAULT_TS_UPDATE_DELAY = 2500;
+export { TickerEvents };
 
 export interface Props extends CommonProps {
   flows: Flow[];
   flowsDiffCount: { value: number };
   selectedFlow: Flow | null;
   onSelectFlow?: (flow: Flow | null) => void;
-  tsUpdateDelay?: number;
+  ticker: Ticker<TickerEvents>;
 }
 
 export const FlowsTable = memo<Props>(function FlowsTable(props: Props) {
   const scroll = useScroll<HTMLDivElement>(props.flowsDiffCount);
-  const tsUpdateDelay = props.tsUpdateDelay ?? DEFAULT_TS_UPDATE_DELAY;
 
   return (
     <div {...scroll} className={css.wrapper}>
@@ -32,7 +34,7 @@ export const FlowsTable = memo<Props>(function FlowsTable(props: Props) {
           isVisibleColumn={props.isVisibleColumn}
           selectedFlow={props.selectedFlow}
           onSelectFlow={props.onSelectFlow}
-          tsUpdateDelay={tsUpdateDelay}
+          ticker={props.ticker}
         />
       </table>
     </div>

--- a/client/src/domain/flows/index.ts
+++ b/client/src/domain/flows/index.ts
@@ -187,7 +187,10 @@ export class Flow {
       return null;
     }
 
-    return new Date(this.ref.time.seconds * 1000).valueOf();
+    const { seconds, nanos } = this.ref.time;
+    const ms = seconds * 1000 + nanos / 1e6;
+
+    return new Date(ms).valueOf();
   }
 
   public get isoTimestamp() {
@@ -217,7 +220,7 @@ export class Flow {
     let timeStr = '';
     if (this.ref.time) {
       const { seconds: s, nanos: n } = this.ref.time;
-      timeStr = `${s}.${n}`;
+      timeStr = `${Math.trunc(s)}.${Math.trunc(n)}`;
     } else {
       // WAT ?
       timeStr = `${Date.now()}`;

--- a/client/src/store/frame.ts
+++ b/client/src/store/frame.ts
@@ -160,7 +160,7 @@ export class StoreFrame {
       links.push(_.cloneDeep(link));
     });
 
-    interactions.setFlows(flows);
+    interactions.setFlows(flows, { sort: true });
     interactions.setLinks(links);
 
     return new StoreFrame(interactions, services, this.controls);

--- a/client/src/store/stores/interaction.ts
+++ b/client/src/store/stores/interaction.ts
@@ -16,9 +16,13 @@ export interface Connections {
   readonly incomings: ConnectionsMap;
 }
 
-interface CopyResult {
+export interface CopyResult {
   newFlows: number;
   newLinks: number;
+}
+
+export interface SetOptions {
+  sort?: boolean;
 }
 
 // This store maintains ANY interactions that may present on the map
@@ -70,13 +74,21 @@ export default class InteractionStore {
   }
 
   @action.bound
-  setHubbleFlows(flows: HubbleFlow[]) {
-    this.flows = flows.map(flowFromRelay);
+  setHubbleFlows(hubbleFlows: HubbleFlow[], opts?: SetOptions) {
+    const flows = hubbleFlows.map(flowFromRelay);
+    return this.setFlows(flows, opts);
   }
 
   @action.bound
-  setFlows(flows: Flow[]) {
-    this.flows = flows;
+  setFlows(flows: Flow[], opts?: SetOptions) {
+    if (!opts?.sort) {
+      this.flows = flows;
+      return;
+    }
+
+    this.flows = flows.slice().sort((a, b) => {
+      return b.millisecondsTimestamp! - a.millisecondsTimestamp!;
+    });
   }
 
   @action.bound

--- a/client/src/store/stores/main.ts
+++ b/client/src/store/stores/main.ts
@@ -63,7 +63,7 @@ export class Store {
   }) {
     this.currentFrame.services.set(services);
     this.currentFrame.interactions.addHubbleLinks(links);
-    this.currentFrame.interactions.setHubbleFlows(flows);
+    this.currentFrame.interactions.setHubbleFlows(flows, { sort: true });
   }
 
   @action.bound

--- a/client/src/utils/emitter.ts
+++ b/client/src/utils/emitter.ts
@@ -1,4 +1,4 @@
-interface HandlerTypes {
+export interface HandlerTypes {
   [event: string]: (...args: any[]) => any;
 }
 

--- a/client/src/utils/ticker.ts
+++ b/client/src/utils/ticker.ts
@@ -1,0 +1,55 @@
+import { EventEmitter, HandlerTypes } from './emitter';
+
+type TimerId = ReturnType<typeof setInterval>;
+
+interface TickDescriptor<K> {
+  name: K;
+  timerId: TimerId;
+  delay: number;
+}
+
+type Handlers<T extends keyof any> = {
+  [P in T]: () => void;
+};
+
+export class Ticker<K extends keyof any> extends EventEmitter<Handlers<K>> {
+  private ticks: Map<string, TickDescriptor<K>>;
+
+  constructor() {
+    super();
+
+    this.ticks = new Map();
+  }
+
+  public start(tickName: K, delay: number) {
+    const current = this.ticks.get(tickName as string);
+    if (current != null) {
+      clearInterval(current.timerId);
+    }
+
+    const timerId = setInterval(() => {
+      (this.emit as any)(tickName);
+    }, delay);
+
+    this.ticks.set(tickName as string, {
+      name: tickName,
+      timerId,
+      delay,
+    });
+  }
+
+  public stop(tickName: string) {
+    const desc = this.ticks.get(tickName);
+    if (desc == null) return;
+
+    clearInterval(desc.timerId);
+    this.ticks.delete(tickName);
+  }
+
+  public delayOf(tickName: string): number | undefined {
+    const desc = this.ticks.get(tickName);
+    if (desc == null) return undefined;
+
+    return desc.delay;
+  }
+}


### PR DESCRIPTION
* FEAT: new util class `Ticker` - emits named tick event during specified interval
* FIX: now `App` uses its own `ticker` to synchronize timestamp update in every `FlowsTable` `Row`
* FIX: properly sort flows when using mock data