### PR TITLE
fix: tests for filtering module

### DIFF
--- a/src/components/App/DataManager.ts
+++ b/src/components/App/DataManager.ts
@@ -5,6 +5,10 @@ import { GeneralStreamEventKind } from '~/api/general/stream';
 
 import { HubbleFlow } from '~/domain/hubble';
 import { Filters, areFiltersEqual, filterFlow } from '~/domain/filtering';
+import { Flow } from '~/domain/flows';
+import { flowFromRelay } from '~/domain/helpers';
+import { StateChange, setupDebugProp } from '~/domain/misc';
+
 import { EventEmitter } from '~/utils/emitter';
 import {
   EventParamsSet,
@@ -17,9 +21,6 @@ import {
 } from '~/api/general/event-stream';
 
 import { Store, StoreFrame } from '~/store';
-import { StateChange } from '~/domain/misc';
-import { flowFromRelay } from '~/domain/helpers';
-import { Flow } from '~/domain/flows';
 
 export enum EventKind {
   StreamError = 'stream-error',
@@ -55,6 +56,12 @@ export class DataManager extends EventEmitter<Events> {
 
     this.api = api;
     this.store = store;
+
+    setupDebugProp({
+      stopAllStreams: () => {
+        this.stopAllStreams();
+      },
+    });
   }
 
   public setupMock() {
@@ -187,6 +194,23 @@ export class DataManager extends EventEmitter<Events> {
 
   private offAllStreamEvents(stream: IEventStream) {
     stream.offAllEvents();
+  }
+
+  private stopAllStreams() {
+    if (this.mainStream) {
+      this.mainStream.stream.stop();
+      this.offAllStreamEvents(this.mainStream.stream);
+    }
+
+    if (this.initialStream) {
+      this.initialStream.stream.stop();
+      this.offAllStreamEvents(this.initialStream.stream);
+    }
+
+    if (this.filteringStream) {
+      this.filteringStream.stream.stop();
+      this.offAllStreamEvents(this.filteringStream.stream);
+    }
   }
 
   public get flowsDelay(): number | undefined {

--- a/src/components/ArrowsRenderer/index.tsx
+++ b/src/components/ArrowsRenderer/index.tsx
@@ -145,7 +145,7 @@ const arrowHandleId = (handle: [Vec2, Vec2]): string => {
   const mid = gutils.linterp2(from, to, 0.5);
 
   // WARN: precision lose here
-  return `${mid.x | 0},${mid.y | 0}`;
+  return `${Math.trunc(mid.x)},${Math.trunc(mid.y)}`;
 };
 
 const arrowHandleEnter = (enter: any) => {
@@ -347,8 +347,8 @@ const manageArrows = (props: Props, g: SVGGElement) => {
 
       // prettier-ignore
       arrows.push([fromToId, {
-          points: allPoints,
-          handles: arrowHandles,
+        points: allPoints,
+        handles: arrowHandles,
       }]);
 
       const connector = connectorArrow.connector;

--- a/src/domain/filtering/__tests__/filter-flow.test.ts
+++ b/src/domain/filtering/__tests__/filter-flow.test.ts
@@ -1,0 +1,887 @@
+import {
+  Filters,
+  filterFlow,
+  filterFlowUsingBasicEntry,
+} from '~/domain/filtering';
+
+import { Verdict } from '~/domain/hubble';
+import {
+  Flow,
+  FlowsFilterEntry,
+  FlowsFilterKind,
+  FlowsFilterDirection,
+} from '~/domain/flows';
+import * as combinations from '~/utils/iter-tools/combinations';
+import { flows } from '~/testing/data';
+import { Dictionary } from '~/domain/misc';
+
+const testFilterEntry = (
+  captionFn: (flowName: string, testNum: number) => string,
+  entry: FlowsFilterEntry,
+  expected: boolean,
+  flows: Dictionary<Flow>,
+) => {
+  Object.keys(flows).forEach((flowName: string, lidx: number) => {
+    const flow = flows[flowName];
+    const caption = captionFn(flowName, lidx + 1);
+
+    test(caption, () => {
+      const result = filterFlowUsingBasicEntry(flow, entry);
+
+      expect(result).toBe(expected);
+    });
+  });
+};
+
+describe('filterFlow', () => {
+  const sameNsFlow = new Flow(flows.hubbleSameNamespace);
+  const diffNsFlow = new Flow(flows.hubbleOne);
+  const verdictDropped = new Flow(flows.hubbleDropped);
+  const verdictUnknown = new Flow(flows.hubbleVerdictUnknown);
+  const flowHttp200 = new Flow(flows.hubbleWithHttp200);
+  const fromGoogleFlow = new Flow(flows.flowFromGoogle);
+  const toGoogleFlow = new Flow(flows.flowToGoogle);
+  const bothGoogleFlow = new Flow(flows.flowFromToGoogle);
+  const sameIpsFlow = new Flow(flows.sameIps);
+  const sameV6IpsFlow = new Flow(flows.sameV6Ips);
+  const differentIpsFlow = new Flow(flows.differentIps);
+  const toKubeDNSFlow = new Flow(flows.toKubeDNS);
+  const fromKubeDNSFlow = new Flow(flows.fromKubeDNS);
+  const bothKubeDNSFlow = new Flow(flows.fromToKubeDNS);
+  const toHostFlow = new Flow(flows.toHost);
+  const fromHostFlow = new Flow(flows.fromHost);
+  const bothHostFlow = new Flow(flows.fromToHost);
+
+  test('namespace > matches to source and destination', () => {
+    const filters: Filters = {
+      namespace: 'kube-system',
+    };
+
+    const stay = filterFlow(sameNsFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('namespace > doesnt match with source and destination', () => {
+    const filters: Filters = {
+      namespace: 'random-123987-ns',
+    };
+
+    const stay = filterFlow(diffNsFlow, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('namespace > matches with source', () => {
+    const filters: Filters = {
+      namespace: 'SenderNs',
+    };
+
+    const stay = filterFlow(diffNsFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('namespace > matches with destination', () => {
+    const filters: Filters = {
+      namespace: 'ReceiverNs',
+    };
+
+    const stay = filterFlow(diffNsFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches (Forwarded)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterFlow(diffNsFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > doesnt match (Forwarded vs Dropped)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterFlow(diffNsFlow, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match (Forwarded vs Unknown)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterFlow(diffNsFlow, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > matches (Dropped)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterFlow(verdictDropped, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > doesnt match (Dropped vs Forwarded)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterFlow(verdictDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match (Dropped vs Unknown)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterFlow(verdictDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > matches (Unknown)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterFlow(verdictUnknown, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > doesnt match (Unknown vs Forwarded)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterFlow(verdictUnknown, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match (Unknown vs Dropped)', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterFlow(verdictUnknown, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('http status > matches (200)', () => {
+    const filters: Filters = {
+      httpStatus: '200',
+    };
+
+    const stay = filterFlow(flowHttp200, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('http status > doesnt match (400)', () => {
+    const filters: Filters = {
+      httpStatus: '400',
+    };
+
+    const stay = filterFlow(flowHttp200, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('http status > matches (200+)', () => {
+    const filters: Filters = {
+      httpStatus: '200+',
+    };
+
+    const stay = filterFlow(flowHttp200, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('http status > matches (100+)', () => {
+    const filters: Filters = {
+      httpStatus: '100+',
+    };
+
+    const stay = filterFlow(flowHttp200, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('http status > doesnt match (0)', () => {
+    const filters: Filters = {
+      httpStatus: '0',
+    };
+
+    const stay = filterFlow(flowHttp200, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('http status > doesnt match (l7 not presented)', () => {
+    const filters: Filters = {
+      httpStatus: '200',
+    };
+
+    const stay = filterFlow(sameNsFlow, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('to/from KubeDNS flows sanity check', () => {
+    expect(flows.normalOne.sourceLabelProps.isKubeDNS).toBe(false);
+    expect(flows.normalOne.destinationLabelProps.isKubeDNS).toBe(false);
+
+    expect(toKubeDNSFlow.sourceLabelProps.isKubeDNS).toBe(false);
+    expect(toKubeDNSFlow.destinationLabelProps.isKubeDNS).toBe(true);
+
+    expect(fromKubeDNSFlow.sourceLabelProps.isKubeDNS).toBe(true);
+    expect(fromKubeDNSFlow.destinationLabelProps.isKubeDNS).toBe(false);
+
+    expect(bothKubeDNSFlow.sourceLabelProps.isKubeDNS).toBe(true);
+    expect(bothKubeDNSFlow.destinationLabelProps.isKubeDNS).toBe(true);
+  });
+
+  // All filters on skip KubeDNS / skip host preserve target flow since
+  // they are just visual (service) filters and should be violate
+  // data on flows table
+  test('skip kube dns > flow not skipped 1', () => {
+    const filters: Filters = {
+      skipKubeDns: true,
+    };
+
+    const stay = filterFlow(flows.normalOne, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 2', () => {
+    const filters: Filters = {
+      skipKubeDns: false,
+    };
+
+    const stay = filterFlow(flows.normalOne, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 3', () => {
+    const filters: Filters = {
+      skipKubeDns: true,
+    };
+
+    const stay = filterFlow(toKubeDNSFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 4', () => {
+    const filters: Filters = {
+      skipKubeDns: false,
+    };
+
+    const stay = filterFlow(toKubeDNSFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 5', () => {
+    const filters: Filters = {
+      skipKubeDns: true,
+    };
+
+    const stay = filterFlow(fromKubeDNSFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 6', () => {
+    const filters: Filters = {
+      skipKubeDns: false,
+    };
+
+    const stay = filterFlow(fromKubeDNSFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 7', () => {
+    const filters: Filters = {
+      skipKubeDns: true,
+    };
+
+    const stay = filterFlow(bothKubeDNSFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip kube dns > flow not skipped 8', () => {
+    const filters: Filters = {
+      skipKubeDns: false,
+    };
+
+    const stay = filterFlow(bothKubeDNSFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('to/from host flows sanity check', () => {
+    expect(flows.normalOne.sourceLabelProps.isHost).toBe(false);
+    expect(flows.normalOne.destinationLabelProps.isHost).toBe(false);
+
+    expect(toHostFlow.sourceLabelProps.isHost).toBe(false);
+    expect(toHostFlow.destinationLabelProps.isHost).toBe(true);
+
+    expect(fromHostFlow.sourceLabelProps.isHost).toBe(true);
+    expect(fromHostFlow.destinationLabelProps.isHost).toBe(false);
+
+    expect(bothHostFlow.sourceLabelProps.isHost).toBe(true);
+    expect(bothHostFlow.destinationLabelProps.isHost).toBe(true);
+  });
+
+  test('skip host > flow not skipped 1', () => {
+    const filters: Filters = {
+      skipHost: true,
+    };
+
+    const stay = filterFlow(flows.normalOne, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 2', () => {
+    const filters: Filters = {
+      skipHost: false,
+    };
+
+    const stay = filterFlow(flows.normalOne, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 3', () => {
+    const filters: Filters = {
+      skipHost: true,
+    };
+
+    const stay = filterFlow(fromHostFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 4', () => {
+    const filters: Filters = {
+      skipHost: false,
+    };
+
+    const stay = filterFlow(fromHostFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 5', () => {
+    const filters: Filters = {
+      skipHost: true,
+    };
+
+    const stay = filterFlow(toHostFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 6', () => {
+    const filters: Filters = {
+      skipHost: false,
+    };
+
+    const stay = filterFlow(toHostFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 7', () => {
+    const filters: Filters = {
+      skipHost: true,
+    };
+
+    const stay = filterFlow(bothHostFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('skip host > flow not skipped 8', () => {
+    const filters: Filters = {
+      skipHost: false,
+    };
+
+    const stay = filterFlow(bothHostFlow, filters);
+    expect(stay).toBe(true);
+  });
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `labels > from matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:label=namespace=SenderNs`)!,
+    true,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      flowHttp200,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `labels > from doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:label=namespace=SenderNs`)!,
+    false,
+    {
+      sameNsFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `labels > to matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:label=namespace=ReceiverNs`)!,
+    true,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      fromKubeDNSFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `labels > to doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:label=namespace=SenderNs`)!,
+    false,
+    {
+      sameNsFlow,
+      toKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `labels > both matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:label=namespace=SenderNs`)!,
+    true,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `labels > both doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:label=namespace=random-123987-ns`)!,
+    false,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `dns > from matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:dns=www.google.com`)!,
+    true,
+    {
+      fromGoogleFlow,
+      bothGoogleFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `dns > from doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:dns=www.google.com`)!,
+    false,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      toGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `dns > to matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:dns=www.google.com`)!,
+    true,
+    {
+      toGoogleFlow,
+      bothGoogleFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `dns > to doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:dns=www.google.com`)!,
+    false,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `dns > both matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:dns=www.google.com`)!,
+    true,
+    {
+      toGoogleFlow,
+      fromGoogleFlow,
+      bothGoogleFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `dns > both doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:dns=www.google.com`)!,
+    false,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `ip > from matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:ip=${sameIpsFlow.sourceIp}`)!,
+    true,
+    {
+      sameIpsFlow,
+      differentIpsFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `ip > from doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:ip=0.0.0.0`)!,
+    false,
+    {
+      sameIpsFlow,
+      differentIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) => `ip > to matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:ip=${differentIpsFlow.destinationIp}`)!,
+    true,
+    {
+      differentIpsFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `ip > to doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:ip=${differentIpsFlow.destinationIp}`)!,
+    false,
+    {
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `ip > both matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:ip=${differentIpsFlow.sourceIp}`)!,
+    true,
+    {
+      differentIpsFlow,
+      sameIpsFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `ip > both doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:ip=0.0.0.0`)!,
+    false,
+    {
+      sameIpsFlow,
+      differentIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > from matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:identity=0`)!,
+    true,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > from doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`from:identity=1`)!,
+    false,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > to matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:identity=1`)!,
+    true,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > to doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`to:identity=0`)!,
+    false,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > both matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:identity=0`)!,
+    true,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > both matches ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:identity=1`)!,
+    true,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `identity > both doesnt match ${tnum} (${flowName})`,
+    FlowsFilterEntry.parse(`both:identity=100500`)!,
+    false,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+});

--- a/src/domain/filtering/__tests__/filter-link.test.ts
+++ b/src/domain/filtering/__tests__/filter-link.test.ts
@@ -1,0 +1,400 @@
+import {
+  Filters,
+  filterLink,
+  filterLinkUsingBasicEntry,
+} from '~/domain/filtering';
+
+import { Verdict } from '~/domain/hubble';
+import { Link } from '~/domain/link';
+import { Flow, FlowsFilterEntry } from '~/domain/flows';
+import { Dictionary } from '~/domain/misc';
+import { links } from '~/testing/data';
+
+const runUnusedFiltersTests = (filters: Filters[], links: Dictionary<Link>) => {
+  Object.keys(links).forEach((linkName: string) => {
+    const link = links[linkName];
+
+    filters.forEach((f: Filters, fidx: number) => {
+      test(`unused filter fields test, link: ${linkName}, filters: ${
+        fidx + 1
+      }`, () => {
+        const stay = filterLink(link, f);
+        expect(stay).toBe(true);
+      });
+    });
+  });
+};
+
+const testFilterEntry = (
+  captionFn: (linkName: string, testNum: number) => string,
+  entry: FlowsFilterEntry,
+  expected: boolean,
+  links: Dictionary<Link>,
+) => {
+  Object.keys(links).forEach((linkName: string, lidx: number) => {
+    const link = links[linkName];
+    const caption = captionFn(linkName, lidx + 1);
+
+    test(caption, () => {
+      const result = filterLinkUsingBasicEntry(link, entry);
+
+      expect(result).toBe(expected);
+    });
+  });
+};
+
+describe('filterLink', () => {
+  const tcpForwarded = Link.fromHubbleLink(links.tcpForwarded);
+  const tcpDropped = Link.fromHubbleLink(links.tcpDropped);
+  const tcpUnknown = Link.fromHubbleLink(links.tcpUnknown);
+  const tcpError = Link.fromHubbleLink(links.tcpError);
+  const tcpForwardedToItself = Link.fromHubbleLink(links.tcpForwardedToItself);
+  const tcpDroppedToItself = Link.fromHubbleLink(links.tcpDroppedToItself);
+  const { tcpForwardedDropped, tcpMixed } = links;
+
+  test('verdict > matches 1', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterLink(tcpForwarded, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 2', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterLink(tcpDropped, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 3', () => {
+    const filters: Filters = {
+      verdict: Verdict.Error,
+    };
+
+    const stay = filterLink(tcpError, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 4', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterLink(tcpUnknown, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 5', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterLink(tcpForwardedDropped, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 6', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterLink(tcpForwardedDropped, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 7', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterLink(tcpMixed, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 8', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterLink(tcpMixed, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 9', () => {
+    const filters: Filters = {
+      verdict: Verdict.Error,
+    };
+
+    const stay = filterLink(tcpMixed, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > matches 10', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterLink(tcpMixed, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('verdict > doesnt match 1', () => {
+    const filters: Filters = {
+      verdict: Verdict.Forwarded,
+    };
+
+    const stay = filterLink(tcpDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 2', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterLink(tcpDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 3', () => {
+    const filters: Filters = {
+      verdict: Verdict.Error,
+    };
+
+    const stay = filterLink(tcpDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 4', () => {
+    const filters: Filters = {
+      verdict: Verdict.Dropped,
+    };
+
+    const stay = filterLink(tcpForwarded, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 5', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterLink(tcpForwarded, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 6', () => {
+    const filters: Filters = {
+      verdict: Verdict.Error,
+    };
+
+    const stay = filterLink(tcpForwarded, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 7', () => {
+    const filters: Filters = {
+      verdict: Verdict.Error,
+    };
+
+    const stay = filterLink(tcpForwardedDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('verdict > doesnt match 8', () => {
+    const filters: Filters = {
+      verdict: Verdict.Unknown,
+    };
+
+    const stay = filterLink(tcpForwardedDropped, filters);
+    expect(stay).toBe(false);
+  });
+
+  testFilterEntry(
+    (linkName: string, n: number) => `identity > to matches ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`to:identity=dst-456`)!,
+    true,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > to doesnt match ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`to:identity=dst-456-wrong`)!,
+    false,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) => `identity > to matches ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`to:identity=src-123`)!,
+    true,
+    {
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > to doesnt match ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`to:identity=src-123-wrong`)!,
+    false,
+    {
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > from matches ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`from:identity=src-123`)!,
+    true,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > from doesnt match ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`from:identity=src-123-wrong`)!,
+    false,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > both matches ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`both:identity=src-123`)!,
+    true,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > both doesnt match ${n} (${linkName})`,
+    FlowsFilterEntry.parse(`both:identity=src-123-wrong`)!,
+    false,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  // These filters don't work for links since they don't have enough information
+  // to decide drop or not to drop, hence links are always passed
+  runUnusedFiltersTests(
+    [
+      { namespace: 'random-ns' },
+      { httpStatus: '200' },
+      { httpStatus: '200+' },
+      { httpStatus: '400' },
+      { skipHost: true },
+      { skipHost: false },
+      { skipKubeDns: true },
+      { skipKubeDns: false },
+      { skipHost: true, skipKubeDns: true },
+      { skipHost: true, skipKubeDns: true, namespace: 'random-ns' },
+      {
+        skipHost: true,
+        skipKubeDns: true,
+        namespace: 'random-ns',
+        httpStatus: '200',
+      },
+      {
+        filters: [FlowsFilterEntry.parse('from:dns=www.google.com')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('to:dns=www.google.com')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('both:dns=www.google.com')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('from:label=k8s:k8s-app=random-app')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('to:label=k8s:k8s-app=random-app')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('both:label=k8s:k8s-app=random-app')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('from:ip=153.82.167.250')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('to:ip=153.82.167.250')!],
+      },
+      {
+        filters: [FlowsFilterEntry.parse('both:ip=153.82.167.250')!],
+      },
+      {
+        filters: [
+          FlowsFilterEntry.parse('from:ip=153.82.167.250')!,
+          FlowsFilterEntry.parse('to:label=k8s:k8s-app=random-app')!,
+        ],
+      },
+    ],
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedDropped,
+      tcpMixed,
+      tcpForwardedToItself,
+      tcpDroppedToItself,
+    },
+  );
+});

--- a/src/domain/filtering/__tests__/filter-service.test.ts
+++ b/src/domain/filtering/__tests__/filter-service.test.ts
@@ -1,0 +1,444 @@
+import {
+  Filters,
+  filterService,
+  filterServiceUsingBasicEntry,
+} from '~/domain/filtering';
+
+import { ServiceCard } from '~/domain/service-card';
+import { Verdict } from '~/domain/hubble';
+import { Dictionary } from '~/domain/misc';
+import { services } from '~/testing/data';
+import {
+  FlowsFilterEntry,
+  FlowsFilterKind,
+  FlowsFilterDirection,
+} from '~/domain/flows';
+
+import { expectFilterEntry } from './general';
+
+const runUnusedFiltersTests = (
+  filters: Filters[],
+  services: Dictionary<ServiceCard>,
+) => {
+  Object.keys(services).forEach((linkName: string) => {
+    const service = services[linkName];
+
+    filters.forEach((f: Filters, fidx: number) => {
+      test(`unused filter fields test, service: ${linkName}, filters: ${
+        fidx + 1
+      }`, () => {
+        const stay = filterService(service, f);
+        expect(stay).toBe(true);
+      });
+    });
+  });
+};
+
+const testFilterEntry = (
+  captionFn: (serviceName: string, testNum: number) => string,
+  entry: FlowsFilterEntry,
+  expected: boolean,
+  services: Dictionary<ServiceCard>,
+) => {
+  Object.keys(services).forEach((serviceName: string, lidx: number) => {
+    const service = services[serviceName].service;
+    const caption = captionFn(serviceName, lidx + 1);
+
+    test(caption, () => {
+      const result = filterServiceUsingBasicEntry(service, entry);
+
+      expect(result).toBe(expected);
+    });
+  });
+};
+
+describe('filterService', () => {
+  const regular = ServiceCard.fromService(services.regular);
+  const world = ServiceCard.fromService(services.world);
+  const host = ServiceCard.fromService(services.host);
+  const remoteNode = ServiceCard.fromService(services.remoteNode);
+  const kubeDns = ServiceCard.fromService(services.kubeDNS);
+
+  const filterEntries = {
+    fromLabelRegular: FlowsFilterEntry.parse(
+      `from:label=k8s:k8s-app=regular-service`,
+    ),
+    toLabelRegular: FlowsFilterEntry.parse(
+      `to:label=k8s:k8s-app=regular-service`,
+    ),
+    bothLabelRegular: FlowsFilterEntry.parse(
+      `both:label=k8s:k8s-app=regular-service`,
+    ),
+    toDnsGoogle: FlowsFilterEntry.parse(`to:dns=www.google.com`),
+    fromDnsGoogle: FlowsFilterEntry.parse(`from:dns=www.google.com`),
+    bothDnsGoogle: FlowsFilterEntry.parse(`both:dns=www.google.com`),
+    fromIpRandom: FlowsFilterEntry.parse(`from:ip=153.82.167.250`),
+    toIpRandom: FlowsFilterEntry.parse(`to:ip=153.82.167.250`),
+    bothIpRandom: FlowsFilterEntry.parse(`both:ip=153.82.167.250`),
+  };
+
+  test('mock data sanity check', () => {
+    expect(regular.isWorld).toBe(false);
+    expect(regular.isHost).toBe(false);
+    expect(regular.isKubeDNS).toBe(false);
+    expect(regular.isPrometheusApp).toBe(false);
+    expect(regular.isRemoteNode).toBe(false);
+
+    expect(world.isWorld).toBe(true);
+    expect(world.isHost).toBe(false);
+    expect(world.isKubeDNS).toBe(false);
+    expect(world.isPrometheusApp).toBe(false);
+    expect(world.isRemoteNode).toBe(false);
+
+    expect(host.isWorld).toBe(false);
+    expect(host.isHost).toBe(true);
+    expect(host.isKubeDNS).toBe(false);
+    expect(host.isPrometheusApp).toBe(false);
+    expect(host.isRemoteNode).toBe(false);
+
+    expect(remoteNode.isWorld).toBe(false);
+    expect(remoteNode.isHost).toBe(false);
+    expect(remoteNode.isKubeDNS).toBe(false);
+    expect(remoteNode.isPrometheusApp).toBe(false);
+    expect(remoteNode.isRemoteNode).toBe(true);
+
+    expect(kubeDns.isWorld).toBe(false);
+    expect(kubeDns.isHost).toBe(false);
+    expect(kubeDns.isKubeDNS).toBe(true);
+    expect(kubeDns.isPrometheusApp).toBe(false);
+    expect(kubeDns.isRemoteNode).toBe(false);
+  });
+
+  test('prepared filter entries sanity check', () => {
+    expectFilterEntry(filterEntries.fromLabelRegular, [
+      FlowsFilterKind.Label,
+      FlowsFilterDirection.From,
+      'k8s:k8s-app=regular-service',
+    ]);
+
+    expectFilterEntry(filterEntries.toLabelRegular, [
+      FlowsFilterKind.Label,
+      FlowsFilterDirection.To,
+      'k8s:k8s-app=regular-service',
+    ]);
+
+    expectFilterEntry(filterEntries.bothLabelRegular, [
+      FlowsFilterKind.Label,
+      FlowsFilterDirection.Both,
+      'k8s:k8s-app=regular-service',
+    ]);
+
+    expectFilterEntry(filterEntries.fromDnsGoogle, [
+      FlowsFilterKind.Dns,
+      FlowsFilterDirection.From,
+      'www.google.com',
+    ]);
+
+    expectFilterEntry(filterEntries.toDnsGoogle, [
+      FlowsFilterKind.Dns,
+      FlowsFilterDirection.To,
+      'www.google.com',
+    ]);
+
+    expectFilterEntry(filterEntries.bothDnsGoogle, [
+      FlowsFilterKind.Dns,
+      FlowsFilterDirection.Both,
+      'www.google.com',
+    ]);
+
+    expectFilterEntry(filterEntries.fromIpRandom, [
+      FlowsFilterKind.Ip,
+      FlowsFilterDirection.From,
+      '153.82.167.250',
+    ]);
+
+    expectFilterEntry(filterEntries.toIpRandom, [
+      FlowsFilterKind.Ip,
+      FlowsFilterDirection.To,
+      '153.82.167.250',
+    ]);
+
+    expectFilterEntry(filterEntries.bothIpRandom, [
+      FlowsFilterKind.Ip,
+      FlowsFilterDirection.Both,
+      '153.82.167.250',
+    ]);
+  });
+
+  test('host > doesnt match (skipHost = true)', () => {
+    const filters: Filters = {
+      skipHost: true,
+    };
+
+    const stay = filterService(host, filters);
+    expect(stay).toBe(false);
+  });
+
+  test('host > matches (skipHost = false)', () => {
+    const filters: Filters = {
+      skipHost: false,
+    };
+
+    const stay = filterService(host, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('host > matches (skipKubeDns = true)', () => {
+    const filters: Filters = {
+      skipKubeDns: true,
+    };
+
+    const stay = filterService(host, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('kubeDns > matches (skipHost = true)', () => {
+    const filters: Filters = {
+      skipHost: true,
+    };
+
+    const stay = filterService(kubeDns, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('kubeDns > matches (skipHost = false)', () => {
+    const filters: Filters = {
+      skipHost: false,
+    };
+
+    const stay = filterService(kubeDns, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('kubeDns > matches (skipKubeDns = false)', () => {
+    const filters: Filters = {
+      skipKubeDns: false,
+    };
+
+    const stay = filterService(kubeDns, filters);
+    expect(stay).toBe(true);
+  });
+
+  test('kubeDns > doesnt match (skipKubeDns = true)', () => {
+    const filters: Filters = {
+      skipKubeDns: true,
+    };
+
+    const stay = filterService(kubeDns, filters);
+    expect(stay).toBe(false);
+  });
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > to matches ${tnum} (${svcName})`,
+    FlowsFilterEntry.parse(`to:identity=${regular.id}`)!,
+    true,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > to doesnt match ${tnum} (${svcName})`,
+    FlowsFilterEntry.parse(`to:identity=${regular.id}`)!,
+    false,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > from matches ${tnum} (${svcName})`,
+    FlowsFilterEntry.parse(`from:identity=${regular.id}`)!,
+    true,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > from doesnt match ${tnum} (${svcName})`,
+    FlowsFilterEntry.parse(`from:identity=${regular.id}`)!,
+    false,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > both matches ${tnum} (${svcName})`,
+    FlowsFilterEntry.parse(`both:identity=${regular.id}`)!,
+    true,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > both doesnt match ${tnum} (${svcName})`,
+    FlowsFilterEntry.parse(`both:identity=${regular.id}`)!,
+    false,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `label > to matches ${tnum} (${svcName})`,
+    filterEntries.toLabelRegular!,
+    true,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `label > to doesnt match ${tnum} (${svcName})`,
+    filterEntries.toLabelRegular!,
+    false,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `label > from matches ${tnum} (${svcName})`,
+    filterEntries.fromLabelRegular!,
+    true,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `label > from doesnt match ${tnum} (${svcName})`,
+    filterEntries.fromLabelRegular!,
+    false,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `label > both matches ${tnum} (${svcName})`,
+    filterEntries.bothLabelRegular!,
+    true,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `label > both doesnt match ${tnum} (${svcName})`,
+    filterEntries.bothLabelRegular!,
+    false,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) => `dns > to matches ${tnum} (${svcName})`,
+    filterEntries.toDnsGoogle!,
+    true,
+    { world },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `dns > to doesnt match ${tnum} (${svcName})`,
+    filterEntries.toDnsGoogle!,
+    false,
+    {
+      regular,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `dns > from matches ${tnum} (${svcName})`,
+    filterEntries.fromDnsGoogle!,
+    true,
+    { world },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `dns > from doesnt match ${tnum} (${svcName})`,
+    filterEntries.fromDnsGoogle!,
+    false,
+    {
+      regular,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `dns > both matches ${tnum} (${svcName})`,
+    filterEntries.bothDnsGoogle!,
+    true,
+    { world },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `dns > both doesnt match ${tnum} (${svcName})`,
+    filterEntries.bothDnsGoogle!,
+    false,
+    {
+      regular,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  runUnusedFiltersTests(
+    [
+      { namespace: 'random-ns' },
+      { httpStatus: '200' },
+      { httpStatus: '200+' },
+      { httpStatus: '400' },
+      { namespace: 'random-ns', httpStatus: '200' },
+      {
+        filters: [filterEntries.fromIpRandom!],
+      },
+      {
+        filters: [filterEntries.toIpRandom!],
+      },
+      {
+        filters: [filterEntries.bothIpRandom!],
+      },
+    ],
+    {
+      regular,
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+});

--- a/src/domain/filtering/__tests__/filters-equality.test.ts
+++ b/src/domain/filtering/__tests__/filters-equality.test.ts
@@ -1,0 +1,91 @@
+import { Filters, areFiltersEqual } from '~/domain/filtering';
+import { FlowsFilterEntry } from '~/domain/flows';
+import { Verdict } from '~/domain/hubble';
+
+import * as combinations from '~/utils/iter-tools/combinations';
+
+const nextElem = (idx: number, arr: any[]) => {
+  return arr[(idx + 1) % arr.length];
+};
+
+const testCommonFiltersEquality = () => {
+  const namespaces: Array<undefined | null | string> = [
+    undefined,
+    null,
+    'random',
+  ];
+
+  const verdicts: Array<Verdict | undefined | null> = [
+    undefined,
+    null,
+    Verdict.Forwarded,
+    Verdict.Dropped,
+  ];
+
+  const httpStatuses: Array<undefined | null | string> = [
+    undefined,
+    null,
+    '200',
+    '200+',
+    '400',
+  ];
+
+  const filters: Array<undefined | FlowsFilterEntry[]> = [
+    undefined,
+    [
+      FlowsFilterEntry.parse('both:dns=google.com')!,
+      FlowsFilterEntry.parse('from:ip=255.255.255.255')!,
+    ],
+    [
+      FlowsFilterEntry.parse('to:label=k8s-app=core-api')!,
+      FlowsFilterEntry.parse('from:label=k8s-app=crawler')!,
+    ],
+    [FlowsFilterEntry.parse('from:ip=158.183.221.43')!],
+  ];
+
+  const skipHosts: Array<undefined | boolean> = [undefined, false, true];
+  const skipKubeDnss: Array<undefined | boolean> = [undefined, false, true];
+
+  combinations
+    .arrays([
+      namespaces.length,
+      verdicts.length,
+      httpStatuses.length,
+      filters.length,
+      skipHosts.length,
+      skipKubeDnss.length,
+    ])
+    .forEach((indices: number[], idx: number) => {
+      const [nsIdx, verdictIdx, hsIdx, filtersIdx, shIdx, skdIdx] = indices;
+      const aFilters: Filters = {
+        namespace: namespaces[nsIdx],
+        verdict: verdicts[verdictIdx],
+        httpStatus: httpStatuses[hsIdx],
+        filters: filters[filtersIdx],
+        skipHost: skipHosts[shIdx],
+        skipKubeDns: skipKubeDnss[skdIdx],
+      };
+
+      const bFilters: Filters = {
+        namespace: nextElem(nsIdx, namespaces),
+        verdict: nextElem(verdictIdx, verdicts),
+        httpStatus: nextElem(hsIdx, httpStatuses),
+        filters: nextElem(filtersIdx, filters),
+        skipHost: nextElem(shIdx, skipHosts),
+        skipKubeDns: nextElem(skdIdx, skipKubeDnss),
+      };
+
+      test(`test ${idx * 2 + 1} > self-equality`, () => {
+        const sameFilters = Object.assign({}, aFilters);
+        expect(areFiltersEqual(aFilters, sameFilters)).toBe(true);
+      });
+
+      test(`test ${idx * 2 + 2} > inequality`, () => {
+        expect(areFiltersEqual(aFilters, bFilters)).toBe(false);
+      });
+    });
+};
+
+describe('filters equality check tests', () => {
+  testCommonFiltersEquality();
+});

--- a/src/domain/filtering/__tests__/general.ts
+++ b/src/domain/filtering/__tests__/general.ts
@@ -1,0 +1,20 @@
+import {
+  FlowsFilterEntry,
+  FlowsFilterKind,
+  FlowsFilterDirection,
+} from '~/domain/flows';
+
+export const expectFilterEntry = (
+  entry: FlowsFilterEntry | null,
+  expecations: [FlowsFilterKind, FlowsFilterDirection, string],
+) => {
+  expect(entry).toBeTruthy();
+
+  expect(entry!.kind).toBe(expecations[0]);
+  expect(entry!.direction).toBe(expecations[1]);
+  expect(entry!.query).toBe(expecations[2]);
+};
+
+test('dumb test to have this module', () => {
+  expect(1).toBe(1);
+});

--- a/src/domain/filtering/index.ts
+++ b/src/domain/filtering/index.ts
@@ -65,7 +65,15 @@ export const filterFlow = (flow: Flow, filters: Filters): boolean => {
   }
 
   if (filters.httpStatus != null) {
-    if (`${flow.httpStatus}` !== filters.httpStatus) return false;
+    if (flow.httpStatus == null) return false;
+
+    const httpStatus = parseInt(filters.httpStatus);
+    const lastChar = filters.httpStatus.slice(-1);
+    const rangeSign = ['+', '-'].includes(lastChar) ? lastChar : undefined;
+
+    if (!rangeSign && flow.httpStatus !== httpStatus) return false;
+    if (rangeSign === '+' && flow.httpStatus < httpStatus) return false;
+    if (rangeSign === '-' && flow.httpStatus > httpStatus) return false;
   }
 
   let ok = true;

--- a/src/domain/flows/__tests__/FlowsFilterEntry.test.ts
+++ b/src/domain/flows/__tests__/FlowsFilterEntry.test.ts
@@ -67,7 +67,7 @@ describe('correct strings parsing', () => {
     true,
     FlowsFilterDirection.Both,
     FlowsFilterKind.Label,
-    'k8s:app=name',
+    'app=name',
   );
 
   parse(
@@ -76,7 +76,7 @@ describe('correct strings parsing', () => {
     true,
     FlowsFilterDirection.From,
     FlowsFilterKind.Label,
-    'k8s:app=name',
+    'app=name',
   );
 
   parse(
@@ -85,7 +85,7 @@ describe('correct strings parsing', () => {
     true,
     FlowsFilterDirection.To,
     FlowsFilterKind.Label,
-    'k8s:app=name',
+    'app=name',
   );
 
   parse(
@@ -121,7 +121,7 @@ describe('correct strings parsing', () => {
     true,
     FlowsFilterDirection.Both,
     FlowsFilterKind.Label,
-    'k8s:app=name',
+    'app=name',
   );
 
   parse(
@@ -139,7 +139,7 @@ describe('correct strings parsing', () => {
     true,
     FlowsFilterDirection.Both,
     FlowsFilterKind.Label,
-    'k8s:app=name',
+    'app=name',
   );
 
   parse(

--- a/src/domain/flows/flows-filter-entry.ts
+++ b/src/domain/flows/flows-filter-entry.ts
@@ -119,7 +119,7 @@ export class FlowsFilterEntry {
 
     switch (kind) {
       case FlowsFilterKind.Label: {
-        return `k8s:${normalized.replace(/^label=/g, '')}`;
+        return `${normalized.replace(/^label=/g, '')}`;
       }
       case FlowsFilterKind.Ip: {
         return normalized.replace(/^ip=/g, '');

--- a/src/domain/flows/index.ts
+++ b/src/domain/flows/index.ts
@@ -6,11 +6,12 @@ import {
   TrafficDirection,
   TCPFlags,
 } from '~/domain/hubble';
-import { Labels } from '~/domain/labels';
+import { Labels, LabelsProps } from '~/domain/labels';
 import {
   CiliumEventSubTypesCodes,
   CiliumDropReasonCodes,
 } from '~/domain/cilium';
+import { KV } from '~/domain/misc';
 import { memoize } from '~/utils/memoize';
 
 export * from './flows-filter-entry';
@@ -39,6 +40,16 @@ export class Flow {
     }
 
     return `${timeStr}-${this.ref.nodeName}`;
+  }
+
+  @memoize
+  public get sourceLabelProps(): LabelsProps {
+    return Labels.detect(this.sourceLabels);
+  }
+
+  @memoize
+  public get destinationLabelProps(): LabelsProps {
+    return Labels.detect(this.destinationLabels);
   }
 
   public get hubbleFlow(): HubbleFlow {

--- a/src/domain/labels.ts
+++ b/src/domain/labels.ts
@@ -33,6 +33,15 @@ export class Labels {
     'covalent.io/',
   ];
 
+  public static toKV(label: string, normalize = false): KV {
+    const [key, ...rest] = label.split('=');
+
+    return {
+      key: normalize ? Labels.normalizeKey(key) : key,
+      value: rest.join('='),
+    };
+  }
+
   public static normalizeKey(key: string) {
     return Labels.prefixes.reduce(
       (acc, val) => acc.replace(val, ''),
@@ -115,6 +124,7 @@ export class Labels {
       isKubeDNS: false,
       isHealth: false,
       isPrometheusApp: false,
+      appName: undefined,
     };
 
     labels.forEach((kv: KV) => {

--- a/src/testing/data/flows.ts
+++ b/src/testing/data/flows.ts
@@ -5,7 +5,11 @@ import {
   FlowType,
   Endpoint,
   TrafficDirection,
+  L7FlowType,
+  IPVersion,
 } from '~/domain/hubble';
+
+import { SpecialLabel, ReservedLabel } from '~/domain/labels';
 
 const nowMs = Date.now();
 
@@ -22,14 +26,14 @@ export const hubbleOne: HubbleFlow = {
     id: 0,
     identity: 0,
     labelsList: ['app=Sender', 'namespace=SenderNs'],
-    namespace: 'kube-system',
+    namespace: 'SenderNs',
     podName: `sender-a1b2c3`,
   },
   destination: {
     id: 1,
     identity: 1,
     labelsList: ['app=Receiver', 'namespace=ReceiverNs'],
-    namespace: 'kube-system',
+    namespace: 'ReceiverNs',
     podName: `receiver-d4e5f6`,
   },
   sourceNamesList: [],
@@ -85,6 +89,135 @@ export const hubbleDropped: HubbleFlow = {
 export const hubbleVerdictUnknown: HubbleFlow = {
   ...hubbleOne,
   verdict: Verdict.Unknown,
+};
+
+export const hubbleSameNamespace: HubbleFlow = {
+  ...hubbleOne,
+  source: {
+    ...hubbleOne.source,
+    labelsList: ['app=Sender', 'namespace=kube-system'],
+  } as Endpoint,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: ['app=Receiver', 'namespace=kube-system'],
+  } as Endpoint,
+};
+
+export const hubbleWithHttp200: HubbleFlow = {
+  ...hubbleOne,
+  l7: {
+    type: L7FlowType.Response,
+    latencyNs: 52130,
+    http: {
+      code: 200,
+      method: 'GET',
+      url: '/',
+      protocol: '1.1',
+      headersList: [],
+    },
+  },
+};
+
+export const flowFromGoogle: HubbleFlow = {
+  ...hubbleOne,
+  sourceNamesList: ['www.google.com'],
+};
+
+export const flowToGoogle: HubbleFlow = {
+  ...hubbleOne,
+  destinationNamesList: ['www.google.com'],
+};
+
+export const flowFromToGoogle: HubbleFlow = {
+  ...hubbleOne,
+  sourceNamesList: ['www.google.com'],
+  destinationNamesList: ['www.google.com'],
+};
+
+export const differentIps: HubbleFlow = {
+  ...hubbleOne,
+  ip: {
+    source: '70.121.253.10',
+    destination: '214.33.252.11',
+    ipVersion: IPVersion.V4,
+    encrypted: false,
+  },
+};
+
+export const sameIps: HubbleFlow = {
+  ...hubbleOne,
+  ip: {
+    source: '70.121.253.10',
+    destination: '70.121.253.10',
+    ipVersion: IPVersion.V4,
+    encrypted: false,
+  },
+};
+
+export const sameV6Ips: HubbleFlow = {
+  ...hubbleOne,
+  ip: {
+    source: '::ffff:70.121.253.10',
+    destination: '::ffff:70.121.253.10',
+    ipVersion: IPVersion.V6,
+    encrypted: false,
+  },
+};
+
+export const fromKubeDNS: HubbleFlow = {
+  ...hubbleOne,
+  source: {
+    ...hubbleOne.source,
+    labelsList: [`${SpecialLabel.KubeDNS}`],
+  } as Endpoint,
+};
+
+export const toKubeDNS: HubbleFlow = {
+  ...hubbleOne,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: [`${SpecialLabel.KubeDNS}`],
+  } as Endpoint,
+};
+
+export const fromToKubeDNS: HubbleFlow = {
+  ...hubbleOne,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: [`${SpecialLabel.KubeDNS}`],
+  } as Endpoint,
+  source: {
+    ...hubbleOne.source,
+    labelsList: [`${SpecialLabel.KubeDNS}`],
+  } as Endpoint,
+};
+
+export const fromHost: HubbleFlow = {
+  ...hubbleOne,
+  source: {
+    ...hubbleOne.source,
+    labelsList: [`${ReservedLabel.Host}=`],
+  } as Endpoint,
+};
+
+export const toHost: HubbleFlow = {
+  ...hubbleOne,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: [`${ReservedLabel.Host}=`],
+  } as Endpoint,
+};
+
+export const fromToHost: HubbleFlow = {
+  ...hubbleOne,
+  source: {
+    ...hubbleOne.source,
+    labelsList: [`${ReservedLabel.Host}=`],
+  } as Endpoint,
+  destination: {
+    ...hubbleOne.destination,
+    labelsList: [`${ReservedLabel.Host}=`],
+  } as Endpoint,
 };
 
 export const normalOne: Flow = new Flow(hubbleOne);

--- a/src/testing/data/index.ts
+++ b/src/testing/data/index.ts
@@ -1,3 +1,5 @@
 import * as flows from './flows';
+import * as links from './links';
+import * as services from './services';
 
-export { flows };
+export { flows, links, services };

--- a/src/testing/data/links.ts
+++ b/src/testing/data/links.ts
@@ -1,0 +1,64 @@
+import { HubbleLink, IPProtocol, Verdict } from '~/domain/hubble';
+import { Link } from '~/domain/link';
+
+export const tcpForwarded: HubbleLink = {
+  id: 'regular1-link-id',
+  sourceId: 'src-123',
+  destinationId: 'dst-456',
+  destinationPort: 8080,
+  ipProtocol: IPProtocol.TCP,
+  verdict: Verdict.Forwarded,
+};
+
+export const tcpForwardedToItself: HubbleLink = {
+  ...tcpForwarded,
+  destinationId: tcpForwarded.sourceId,
+};
+
+export const tcpDroppedToItself: HubbleLink = {
+  ...tcpForwardedToItself,
+  verdict: Verdict.Dropped,
+};
+
+export const tcpDropped: HubbleLink = {
+  ...tcpForwarded,
+  verdict: Verdict.Dropped,
+};
+
+export const tcpUnknown: HubbleLink = {
+  ...tcpForwarded,
+  verdict: Verdict.Unknown,
+};
+
+export const tcpError: HubbleLink = {
+  ...tcpForwarded,
+  verdict: Verdict.Error,
+};
+
+export const udpForwarded: HubbleLink = {
+  ...tcpForwarded,
+  ipProtocol: IPProtocol.UDP,
+};
+
+export const udpDropped: HubbleLink = {
+  ...udpForwarded,
+  verdict: Verdict.Dropped,
+};
+
+export const udpUnknown: HubbleLink = {
+  ...udpForwarded,
+  verdict: Verdict.Unknown,
+};
+
+export const udpError: HubbleLink = {
+  ...udpForwarded,
+  verdict: Verdict.Error,
+};
+
+export const tcpForwardedDropped = Link.fromHubbleLink(
+  tcpForwarded,
+).updateWithHubbleLink(tcpDropped);
+
+export const tcpMixed = tcpForwardedDropped
+  .updateWithHubbleLink(tcpUnknown)
+  .updateWithHubbleLink(tcpError);

--- a/src/testing/data/services.ts
+++ b/src/testing/data/services.ts
@@ -1,0 +1,60 @@
+import { HubbleService, IPProtocol, Verdict } from '~/domain/hubble';
+import { Link } from '~/domain/link';
+import { Labels, ReservedLabel, SpecialLabel } from '~/domain/labels';
+import { msToPbTimestamp } from '~/domain/helpers';
+
+const restOfService = {
+  egressPolicyEnforced: false,
+  ingressPolicyEnforced: false,
+  visibilityPolicyStatus: '',
+  creationTimestamp: msToPbTimestamp(+new Date(2020, 4, 15)),
+};
+
+export const regular: HubbleService = {
+  id: 'regular-service-id',
+  name: 'regular-service',
+  namespace: 'service-ns',
+  labels: [
+    { key: 'k8s:k8s-app', value: 'regular-service' },
+    { key: 'k8s:namespace', value: 'service-ns' },
+    { key: 'lbl-key', value: 'random-value' },
+  ],
+  dnsNames: [],
+  ...restOfService,
+};
+
+export const world: HubbleService = {
+  id: 'world-service',
+  name: 'world-service',
+  namespace: 'world-service-ns',
+  labels: [Labels.toKV(ReservedLabel.World)],
+  dnsNames: ['www.google.com'],
+  ...restOfService,
+};
+
+export const host: HubbleService = {
+  id: 'host-service',
+  name: 'host-service',
+  namespace: 'host-service-ns',
+  labels: [Labels.toKV(ReservedLabel.Host)],
+  dnsNames: [],
+  ...restOfService,
+};
+
+export const remoteNode: HubbleService = {
+  id: 'remote-node-service',
+  name: 'remote-node-service',
+  namespace: 'remote-node-service-ns',
+  labels: [Labels.toKV(ReservedLabel.RemoteNode)],
+  dnsNames: [],
+  ...restOfService,
+};
+
+export const kubeDNS: HubbleService = {
+  id: 'kube-dns-service',
+  name: 'kube-dns-service',
+  namespace: 'kube-dns-service-ns',
+  labels: [Labels.toKV(SpecialLabel.KubeDNS)],
+  dnsNames: [],
+  ...restOfService,
+};

--- a/src/utils/iter-tools/__tests__/combinations.test.ts
+++ b/src/utils/iter-tools/__tests__/combinations.test.ts
@@ -1,0 +1,106 @@
+import * as combinations from '../combinations';
+
+describe('combinations', () => {
+  test('test 1', () => {
+    const combs = combinations.arrays([2, 2]).asArray();
+    expect(combs).toStrictEqual([
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [1, 1],
+    ]);
+    const cb = jest.fn();
+
+    combinations.arrays([2, 2]).forEach(cb);
+
+    expect(cb.mock.calls.length).toBe(4);
+    expect(cb.mock.calls[0][0]).toStrictEqual([0, 0]);
+    expect(cb.mock.calls[0][1]).toStrictEqual(0);
+    expect(cb.mock.calls[0][2]).toStrictEqual(4);
+
+    expect(cb.mock.calls[1][0]).toStrictEqual([0, 1]);
+    expect(cb.mock.calls[1][1]).toStrictEqual(1);
+    expect(cb.mock.calls[1][2]).toStrictEqual(4);
+
+    expect(cb.mock.calls[2][0]).toStrictEqual([1, 0]);
+    expect(cb.mock.calls[2][1]).toStrictEqual(2);
+    expect(cb.mock.calls[2][2]).toStrictEqual(4);
+
+    expect(cb.mock.calls[3][0]).toStrictEqual([1, 1]);
+    expect(cb.mock.calls[3][1]).toStrictEqual(3);
+    expect(cb.mock.calls[3][2]).toStrictEqual(4);
+  });
+
+  test('test 2', () => {
+    const combs = combinations.arrays([1, 2]).asArray();
+    expect(combs).toStrictEqual([
+      [0, 0],
+      [0, 1],
+    ]);
+
+    const cb = jest.fn();
+    combinations.arrays([1, 2]).forEach(cb);
+
+    expect(cb.mock.calls.length).toBe(2);
+    expect(cb.mock.calls[0][0]).toStrictEqual([0, 0]);
+    expect(cb.mock.calls[0][1]).toStrictEqual(0);
+    expect(cb.mock.calls[0][2]).toStrictEqual(2);
+
+    expect(cb.mock.calls[1][0]).toStrictEqual([0, 1]);
+    expect(cb.mock.calls[1][1]).toStrictEqual(1);
+    expect(cb.mock.calls[1][2]).toStrictEqual(2);
+  });
+
+  test('test 3', () => {
+    const combs = combinations.arrays([1, 1]).asArray();
+    expect(combs).toStrictEqual([[0, 0]]);
+
+    const cb = jest.fn();
+    combinations.arrays([1, 1]).forEach(cb);
+
+    expect(cb.mock.calls.length).toBe(1);
+    expect(cb.mock.calls[0][0]).toStrictEqual([0, 0]);
+    expect(cb.mock.calls[0][1]).toStrictEqual(0);
+    expect(cb.mock.calls[0][2]).toStrictEqual(1);
+  });
+
+  test('test 4', () => {
+    const combs = combinations.arrays([0, 0]).asArray();
+    expect(combs).toStrictEqual([]);
+
+    const cb = jest.fn();
+    combinations.arrays([0, 0]).forEach(cb);
+
+    expect(cb.mock.calls.length).toBe(0);
+  });
+
+  test('test 5', () => {
+    const combs = combinations.arrays([2, 1, 2]).asArray();
+    expect(combs).toStrictEqual([
+      [0, 0, 0],
+      [0, 0, 1],
+      [1, 0, 0],
+      [1, 0, 1],
+    ]);
+
+    const cb = jest.fn();
+    combinations.arrays([2, 1, 2]).forEach(cb);
+
+    expect(cb.mock.calls.length).toBe(4);
+    expect(cb.mock.calls[0][0]).toStrictEqual([0, 0, 0]);
+    expect(cb.mock.calls[0][1]).toStrictEqual(0);
+    expect(cb.mock.calls[0][2]).toStrictEqual(4);
+
+    expect(cb.mock.calls[1][0]).toStrictEqual([0, 0, 1]);
+    expect(cb.mock.calls[1][1]).toStrictEqual(1);
+    expect(cb.mock.calls[1][2]).toStrictEqual(4);
+
+    expect(cb.mock.calls[2][0]).toStrictEqual([1, 0, 0]);
+    expect(cb.mock.calls[2][1]).toStrictEqual(2);
+    expect(cb.mock.calls[2][2]).toStrictEqual(4);
+
+    expect(cb.mock.calls[3][0]).toStrictEqual([1, 0, 1]);
+    expect(cb.mock.calls[3][1]).toStrictEqual(3);
+    expect(cb.mock.calls[3][2]).toStrictEqual(4);
+  });
+});

--- a/src/utils/iter-tools/combinations.ts
+++ b/src/utils/iter-tools/combinations.ts
@@ -1,0 +1,79 @@
+export type ArrayCominationsForEach = (
+  tuple: number[],
+  idx: number,
+  ntotal: number,
+) => void;
+
+export class ArrayCombinations {
+  public tupleSizes: number[];
+  private indices: number[];
+  private stop: boolean;
+  private ntuples: number;
+
+  constructor(tupleSizes: number[]) {
+    this.tupleSizes = tupleSizes;
+    this.indices = Array(tupleSizes.length).fill(0);
+    this.ntuples = tupleSizes.reduce((acc: number, ts: number) => {
+      return acc * ts;
+    }, 1);
+
+    this.stop = this.ntuples === 0;
+  }
+
+  public next(): number[] | null {
+    if (this.stop) return null;
+
+    const current = this.indices.slice();
+    this.advanceIndices();
+
+    return current;
+  }
+
+  public asArray(): number[][] {
+    const arr = [];
+
+    while (true) {
+      const indices = this.next();
+      if (indices == null) break;
+
+      arr.push(indices);
+    }
+
+    return arr;
+  }
+
+  public forEach(fn: ArrayCominationsForEach) {
+    for (let idx = 0; idx < this.ntuples; ++idx) {
+      const tuple = this.next();
+      if (tuple == null) return;
+
+      fn(tuple, idx, this.ntuples);
+    }
+  }
+
+  private advanceIndices() {
+    let idxToIncrement = this.indices.length - 1;
+    let carry = 0;
+
+    while (true) {
+      if (idxToIncrement < 0) {
+        if (carry === 1) {
+          this.stop = true;
+        }
+
+        break;
+      }
+
+      const ts = this.tupleSizes[idxToIncrement];
+      carry = Number(this.indices[idxToIncrement] + 1 >= ts);
+      this.indices[idxToIncrement] = (this.indices[idxToIncrement] + 1) % ts;
+
+      if (carry === 0) break;
+      idxToIncrement -= 1;
+    }
+  }
+}
+
+export const arrays = (tupleSizes: number[]): ArrayCombinations => {
+  return new ArrayCombinations(tupleSizes);
+};


### PR DESCRIPTION
`npx jest ./src/domain/filtering/__tests__/ --coverage`
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                                                                                           
------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 domain/filtering       |   95.74 |    94.52 |   93.33 |   98.29 |                                                                                                                                                                             
  index.ts              |   95.74 |    94.52 |   93.33 |   98.29 | 78-80                                                                                                                                                                       

```
Test Suites: 4 passed, 4 total
Tests:       4947 passed, 4947 total
Snapshots:   0 total
Time:        6.107 s
Ran all test suites matching /.\/src\/domain\/filtering\/__tests__\//i.
```