### PR TITLE
fix: SidebarComponents refactor + Filters is now separate component

### DIFF
--- a/src/api/general/event-stream.ts
+++ b/src/api/general/event-stream.ts
@@ -49,17 +49,6 @@ export interface ServiceLinkChange {
   change: StateChange;
 }
 
-export interface DataFilters {
-  namespace: string;
-  verdict?: Verdict | null;
-  httpStatus?: string | null;
-  filters?: FlowsFilterEntry[];
-  skipHost?: boolean;
-  skipKubeDns?: boolean;
-  skipRemoteNode?: boolean;
-  skipPrometheusApp?: boolean;
-}
-
 export type EventStreamHandlers = GeneralStreamEvents & {
   [EventKind.Flows]: (_: HubbleFlow[]) => void;
   [EventKind.Namespace]: (_: NamespaceChange) => void;

--- a/src/api/general/index.ts
+++ b/src/api/general/index.ts
@@ -1,8 +1,8 @@
 import { HubbleFlow } from '~/domain/flows';
+import { Filters } from '~/domain/filtering';
 import {
   IEventStream,
   EventParams,
-  DataFilters,
   EventStreamHandlers,
   EventKind as EventStreamEventKind,
   NamespaceChange,
@@ -13,7 +13,7 @@ import {
 export interface CoreAPIv1 {
   getEventStream: (
     params?: EventParams,
-    filters?: DataFilters, // TODO: builder pattern ?
+    filters?: Filters, // TODO: builder pattern ?
   ) => IEventStream;
 }
 
@@ -24,7 +24,6 @@ export interface API {
 export {
   IEventStream,
   EventParams,
-  DataFilters,
   EventStreamHandlers,
   EventStreamEventKind,
   NamespaceChange,

--- a/src/api/grpc/event-stream.ts
+++ b/src/api/grpc/event-stream.ts
@@ -17,6 +17,7 @@ import { HubbleFlow } from '~/domain/hubble';
 import { FlowsFilterDirection, FlowsFilterKind } from '~/domain/flows';
 import { CiliumEventTypes } from '~/domain/cilium';
 import { ReservedLabel, SpecialLabel, Labels } from '~/domain/labels';
+import { Filters } from '~/domain/filtering';
 import * as dataHelpers from '~/domain/helpers';
 
 import { EventEmitter } from '~/utils/emitter';
@@ -25,7 +26,6 @@ import {
   EventParams,
   EventStreamHandlers,
   EventKind,
-  DataFilters,
 } from '~/api/general/event-stream';
 import { GeneralStreamEventKind } from '~/api/general/stream';
 
@@ -47,7 +47,7 @@ export class EventStream extends EventEmitter<EventStreamHandlers>
   // TODO: add another params to handle filters
   public static buildRequest(
     opts: EventParams,
-    filters?: DataFilters,
+    filters?: Filters,
   ): GetEventsRequest {
     const req = new GetEventsRequest();
 
@@ -88,7 +88,7 @@ export class EventStream extends EventEmitter<EventStreamHandlers>
   }
 
   // Taken from previous FlowStream class
-  public static buildFlowFilters(filters?: DataFilters): FlowFilters {
+  public static buildFlowFilters(filters?: Filters): FlowFilters {
     const namespace = filters?.namespace;
 
     // *** whitelist filters section ***

--- a/src/api/grpc/index.ts
+++ b/src/api/grpc/index.ts
@@ -1,12 +1,9 @@
 import { UIClient } from '~backend/proto/ui/ui_grpc_web_pb';
 
 import { API, CoreAPIv1, EventParams } from '~/api/general';
-import {
-  IEventStream,
-  EventParamsSet,
-  DataFilters,
-} from '~/api/general/event-stream';
+import { IEventStream, EventParamsSet } from '~/api/general/event-stream';
 import { EventStream } from './event-stream';
+import { Filters } from '~/domain/filtering';
 
 export class APIv1 implements CoreAPIv1 {
   private client: UIClient;
@@ -21,10 +18,7 @@ export class APIv1 implements CoreAPIv1 {
     this.client = new UIClient(`${schema}://${host}:${port}${path}`);
   }
 
-  public getEventStream(
-    params?: EventParams,
-    filters?: DataFilters,
-  ): IEventStream {
+  public getEventStream(params?: EventParams, filters?: Filters): IEventStream {
     params = params || APIv1.defaultEventStreamParams;
 
     const request = EventStream.buildRequest(params, filters);

--- a/src/components/DetailsPanel/index.tsx
+++ b/src/components/DetailsPanel/index.tsx
@@ -9,7 +9,12 @@ import {
   TickerEvents,
   DEFAULT_TS_UPDATE_DELAY,
 } from '~/components/FlowsTable';
-import { FlowsTableSidebar } from '~/components/FlowsTable/Sidebar';
+
+import {
+  FlowsTableSidebar,
+  Props as SidebarProps,
+} from '~/components/FlowsTable/Sidebar';
+
 import { useFlowsTableColumns } from '~/components/FlowsTable/hooks/useColumns';
 import { LoadingOverlay } from '~/components/Misc/LoadingOverlay';
 
@@ -19,10 +24,6 @@ import css from './styles.scss';
 
 export { DEFAULT_TS_UPDATE_DELAY, TickerEvents, OnFlowsDiffCount };
 
-interface SidebarProps {
-  onCloseSidebar?: () => void;
-}
-
 interface PanelProps {
   isStreaming: boolean;
   onPanelResize?: (resizeProps: ResizeProps) => void;
@@ -31,7 +32,18 @@ interface PanelProps {
 
 type TableProps = Omit<FlowsTableProps, 'isVisibleColumn'>;
 
-export type Props = SidebarProps & TableProps & PanelProps;
+export type Props = PanelProps &
+  TableProps & {
+    onCloseSidebar: SidebarProps['onClose'];
+    onSidebarVerdictClick: SidebarProps['onVerdictClick'];
+    onSidebarTCPFlagClick: SidebarProps['onTcpFlagClick'];
+    onSidebarLabelClick: SidebarProps['onLabelClick'];
+    onSidebarPodClick: SidebarProps['onPodClick'];
+    onSidebarIdentityClick: SidebarProps['onIdentityClick'];
+    onSidebarIpClick: SidebarProps['onIpClick'];
+    onSidebarDnsClick: SidebarProps['onDnsClick'];
+    filters: SidebarProps['filters'];
+  };
 
 export const DetailsPanelComponent = function (props: Props) {
   const panelResize = usePanelResize();
@@ -64,9 +76,7 @@ export const DetailsPanelComponent = function (props: Props) {
             flows={props.flows}
             isVisibleColumn={flowsTableColumns.isVisibleColumn}
             selectedFlow={props.selectedFlow}
-            dataFilters={props.dataFilters}
             onSelectFlow={props.onSelectFlow}
-            onSelectFilters={props.onSelectFilters}
             onFlowsDiffCount={props.onFlowsDiffCount}
             ticker={props.ticker}
           />
@@ -78,9 +88,15 @@ export const DetailsPanelComponent = function (props: Props) {
       {props.selectedFlow && (
         <FlowsTableSidebar
           flow={props.selectedFlow}
-          dataFilters={props.dataFilters}
+          filters={props.filters}
           onClose={props.onCloseSidebar}
-          onSelectFilters={props.onSelectFilters}
+          onVerdictClick={props.onSidebarVerdictClick}
+          onTcpFlagClick={props.onSidebarTCPFlagClick}
+          onLabelClick={props.onSidebarLabelClick}
+          onPodClick={props.onSidebarPodClick}
+          onIdentityClick={props.onSidebarIdentityClick}
+          onIpClick={props.onSidebarIpClick}
+          onDnsClick={props.onSidebarDnsClick}
         />
       )}
     </div>

--- a/src/components/FlowsTable/SidebarComponents.tsx
+++ b/src/components/FlowsTable/SidebarComponents.tsx
@@ -7,34 +7,35 @@ import {
   FlowsFilterKind,
   Flow,
 } from '~/domain/flows';
-import { TCPFlags, Verdict } from '~/domain/hubble';
+import { TCPFlags, TCPFlagName, Verdict } from '~/domain/hubble';
 import { KV } from '~/domain/misc';
-
-import { FiltersProps } from './general';
 
 import css from './styles.scss';
 import { Labels } from '~/domain/labels';
 
-export interface BodyFiltersProps extends FiltersProps {
+export interface DirectionProps {
   filterDirection?: FlowsFilterDirection;
 }
 
-export interface LabelsBodyProps extends BodyFiltersProps {
+export interface LabelsEntryProps extends DirectionProps {
   labels: KV[];
+  selected: Set<string>;
+  onClick: (label: KV) => void;
 }
 
-export const LabelsBody = memo<LabelsBodyProps>(
-  function FlowsTableSidebarLabelsBody(props) {
+export const LabelsEntry = memo<LabelsEntryProps>(
+  function FlowsTableSidebarLabelsEntry(props) {
     return (
       <div className={css.labels}>
         {props.labels.map(label => {
+          const isSelected = props.selected.has(Labels.concatKV(label));
+
           return (
-            <LabelsBodyItem
-              key={`${label.key}=${label.value}`}
+            <LabelsEntryItem
+              key={Labels.concatKV(label)}
               label={label}
-              dataFilters={props.dataFilters}
-              filterDirection={props.filterDirection}
-              onSelectFilters={props.onSelectFilters}
+              onClick={props.onClick}
+              isSelected={isSelected}
             />
           );
         })}
@@ -43,50 +44,24 @@ export const LabelsBody = memo<LabelsBodyProps>(
   },
 );
 
-export interface LabelsBodyItemProps extends BodyFiltersProps {
+export interface LabelsEntryItemProps extends DirectionProps {
   label: KV;
+  isSelected: boolean;
+  onClick: (label: KV) => void;
 }
 
-export const LabelsBodyItem = memo<LabelsBodyItemProps>(
-  function FlowsTableSidebarLabelsBodyItem(props) {
-    const isSelected = useMemo(() => {
-      let concatedLabel = props.label.key + '=';
-      if (props.label.value) concatedLabel += props.label.value;
-
-      if (!props.dataFilters?.filters) return false;
-
-      return props.dataFilters.filters.some(filter => {
-        return (
-          filter.kind === FlowsFilterKind.Label &&
-          filter.direction === props.filterDirection &&
-          filter.query === concatedLabel
-        );
-      });
-    }, [props.dataFilters, props.label, props.filterDirection]);
-
+export const LabelsEntryItem = memo<LabelsEntryItemProps>(
+  function FlowsTableSidebarLabelsEntryItem(props) {
     const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        filters: isSelected
-          ? []
-          : [
-              new FlowsFilterEntry({
-                kind: FlowsFilterKind.Label,
-                direction: props.filterDirection ?? FlowsFilterDirection.Both,
-                query: `${props.label.key}=${props.label.value}`,
-              }),
-            ],
-      });
-    }, [props.onSelectFilters, props.label, isSelected]);
+      props.onClick?.(props.label);
+    }, [props.label, props.onClick]);
 
     const className = classnames(css.label, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
+      [css.clickable]: !!props.onClick,
+      [css.selected]: props.isSelected,
     });
 
-    let title = Labels.normalizeKey(props.label.key);
-    if (props.label.value) {
-      title += `=${props.label.value}`;
-    }
+    const title = Labels.concatKV(props.label, true);
 
     return (
       <span className={className} onClick={onClick}>
@@ -96,63 +71,54 @@ export const LabelsBodyItem = memo<LabelsBodyItemProps>(
   },
 );
 
-export interface TCPFlagsBodyProps extends BodyFiltersProps {
-  flags: Array<keyof TCPFlags>;
+export interface TCPFlagsEntryProps {
+  flags: Array<TCPFlagName>;
+  filterDirection?: FlowsFilterDirection;
+  selected?: Set<TCPFlagName>;
+  onClick?: (flag: TCPFlagName) => void;
 }
 
-export const TCPFlagsBody = memo<TCPFlagsBodyProps>(
-  function FlowsTableSidebarTCPFlagsBody(props) {
+export const TCPFlagsEntry = memo<TCPFlagsEntryProps>(
+  function FlowsTableSidebarTCPFlagsEntry(props) {
     return (
       <div className={css.tcpFlags}>
-        {props.flags.map(flag => (
-          <TCPFlagsBodyItem
-            key={flag}
-            flag={flag}
-            dataFilters={props.dataFilters}
-            filterDirection={props.filterDirection}
-            onSelectFilters={props.onSelectFilters}
-          />
-        ))}
+        {props.flags.map(flag => {
+          const isSelected = props.selected ? props.selected.has(flag) : false;
+          const onClick = () => {
+            props.onClick?.(flag);
+          };
+
+          return (
+            <TCPFlagsEntryItem
+              key={flag}
+              flag={flag}
+              isSelected={isSelected}
+              filterDirection={props.filterDirection}
+              onClick={onClick}
+            />
+          );
+        })}
       </div>
     );
   },
 );
 
-export interface TCPFlagsItemProps extends BodyFiltersProps {
-  flag: keyof TCPFlags;
+export interface TCPFlagsItemProps extends DirectionProps {
+  flag: TCPFlagName;
+  filterDirection?: FlowsFilterDirection;
+  isSelected: boolean;
+  onClick?: () => void;
 }
 
-export const TCPFlagsBodyItem = memo<TCPFlagsItemProps>(
-  function FlowsTableSidebarTCPFlagsBodyItem(props) {
-    const isSelected = useMemo(() => {
-      if (!props.dataFilters?.filters) return false;
-
-      return props.dataFilters.filters.some(filter => {
-        return (
-          filter.kind === FlowsFilterKind.TCPFlag &&
-          filter.direction === props.filterDirection &&
-          filter.query === props.flag
-        );
-      });
-    }, [props.dataFilters, props.flag, props.filterDirection]);
-
+export const TCPFlagsEntryItem = memo<TCPFlagsItemProps>(
+  function FlowsTableSidebarTCPFlagsEntryItem(props) {
     const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        filters: isSelected
-          ? []
-          : [
-              new FlowsFilterEntry({
-                kind: FlowsFilterKind.TCPFlag,
-                direction: props.filterDirection ?? FlowsFilterDirection.Both,
-                query: props.flag,
-              }),
-            ],
-      });
-    }, [props.onSelectFilters, props.flag, isSelected]);
+      props.onClick?.();
+    }, [props.onClick]);
 
     const className = classnames(css.tcpFlag, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
+      [css.clickable]: !!props.onClick,
+      [css.selected]: props.isSelected,
     });
 
     return (
@@ -163,115 +129,73 @@ export const TCPFlagsBodyItem = memo<TCPFlagsItemProps>(
   },
 );
 
-export interface VerdictItemProps extends FiltersProps {
+export interface VerdictEntryProps {
   verdict: Verdict;
+  isSelected: boolean;
+  onClick?: () => void;
 }
 
-export const VerdictBodyItem = memo<VerdictItemProps>(
-  function FlowsTableSidebarVerdictBodyItem(props) {
-    const isSelected = props.verdict === props.dataFilters?.verdict;
-
-    const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        verdict: isSelected ? null : props.verdict,
-      });
-    }, [props.onSelectFilters, props.verdict, isSelected]);
-
+export const VerdictEntry = memo<VerdictEntryProps>(
+  function FlowsTableSidebarVerdictEntry(props) {
     const className = classnames(css.verdict, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
+      [css.clickable]: !!props.onClick,
+      [css.selected]: props.isSelected,
       [css.forwardedVerdict]: props.verdict === Verdict.Forwarded,
       [css.droppedVerdict]: props.verdict === Verdict.Dropped,
     });
 
+    const onClick = useCallback(() => {
+      props.onClick?.();
+    }, [props.onClick]);
+
     return (
-      <span className={className} onClick={onClick}>
+      <span className={className} onClick={props.onClick}>
         {Flow.getVerdictLabel(props.verdict)}
       </span>
     );
   },
 );
 
-export interface IPItemProps extends BodyFiltersProps {
+export interface IPItemProps {
   ip: string;
+  isSelected: boolean;
+  onClick?: () => void;
 }
 
-export const IPBodyItem = memo<IPItemProps>(
-  function FlowsTableSidebarIPBodyItem(props) {
-    const isSelected = useMemo(() => {
-      if (!props.dataFilters?.filters) return false;
+export const IPEntry = memo<IPItemProps>(function FlowsTableSidebarIPEntry(
+  props,
+) {
+  const onClick = useCallback(() => {
+    props.onClick?.();
+  }, [props.onClick]);
 
-      return props.dataFilters.filters.some(filter => {
-        return (
-          filter.kind === FlowsFilterKind.Ip &&
-          filter.direction === props.filterDirection &&
-          filter.query === props.ip
-        );
-      });
-    }, [props.dataFilters, props.ip, props.filterDirection]);
+  const className = classnames(css.ip, {
+    [css.clickable]: !!props.onClick,
+    [css.selected]: props.isSelected,
+  });
 
-    const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        filters: isSelected
-          ? []
-          : [
-              new FlowsFilterEntry({
-                kind: FlowsFilterKind.Ip,
-                direction: props.filterDirection ?? FlowsFilterDirection.Both,
-                query: props.ip,
-              }),
-            ],
-      });
-    }, [props.onSelectFilters, props.ip, isSelected]);
+  return (
+    <span className={className} onClick={onClick}>
+      {props.ip}
+    </span>
+  );
+});
 
-    const className = classnames(css.ip, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
-    });
-
-    return (
-      <span className={className} onClick={onClick}>
-        {props.ip}
-      </span>
-    );
-  },
-);
-
-export interface DnsItemProps extends BodyFiltersProps {
+export interface DnsItemProps {
   dns: string;
+  isSelected: boolean;
+  onClick?: () => void;
 }
 
 export const DnsBodyItem = memo<DnsItemProps>(
   function FlowsTableSidebarDnsBodyItem(props) {
-    const isSelected = useMemo(() => {
-      if (!props.dataFilters?.filters) return false;
-
-      return props.dataFilters.filters.some(filter => {
-        return (
-          filter.kind === FlowsFilterKind.Dns &&
-          filter.direction === props.filterDirection &&
-          filter.query === props.dns
-        );
-      });
-    }, [props.dataFilters, props.dns, props.filterDirection]);
-
     const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        filters: isSelected
-          ? []
-          : [
-              new FlowsFilterEntry({
-                kind: FlowsFilterKind.Dns,
-                direction: props.filterDirection ?? FlowsFilterDirection.Both,
-                query: props.dns,
-              }),
-            ],
-      });
-    }, [props.onSelectFilters, props.dns, isSelected]);
+      props.onClick?.();
+    }, [props.onClick]);
 
     const className = classnames(css.dns, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
+      [css.clickable]: !!props.onClick,
+      [css.selected]: props.isSelected,
     });
 
     return (
@@ -282,41 +206,21 @@ export const DnsBodyItem = memo<DnsItemProps>(
   },
 );
 
-export interface IdentityItemProps extends BodyFiltersProps {
+export interface IdentityItemProps {
   identity: number;
+  isSelected: boolean;
+  onClick?: () => void;
 }
 
-export const IdentityBodyItem = memo<IdentityItemProps>(
+export const IdentityEntry = memo<IdentityItemProps>(
   function FlowsTableSidebarIdentityBodyItem(props) {
-    const isSelected = useMemo(() => {
-      if (!props.dataFilters?.filters) return false;
-
-      return props.dataFilters.filters.some(filter => {
-        return (
-          filter.kind === FlowsFilterKind.Identity &&
-          filter.direction === props.filterDirection &&
-          filter.query === String(props.identity)
-        );
-      });
-    }, [props.dataFilters, props.identity, props.filterDirection]);
-
     const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        filters: isSelected
-          ? []
-          : [
-              new FlowsFilterEntry({
-                kind: FlowsFilterKind.Identity,
-                direction: props.filterDirection ?? FlowsFilterDirection.Both,
-                query: String(props.identity),
-              }),
-            ],
-      });
-    }, [props.onSelectFilters, props.identity, isSelected]);
+      props.onClick?.();
+    }, [props.onClick]);
 
     const className = classnames(css.identity, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
+      [css.clickable]: !!props.onClick,
+      [css.selected]: props.isSelected,
     });
 
     return (
@@ -327,47 +231,27 @@ export const IdentityBodyItem = memo<IdentityItemProps>(
   },
 );
 
-export interface PodItemProps extends BodyFiltersProps {
+export interface PodItemProps {
   pod: string;
+  isSelected: boolean;
+  onClick?: (podName: string) => void;
 }
 
-export const PodBodyItem = memo<PodItemProps>(
-  function FlowsTableSidebarPodBodyItem(props) {
-    const isSelected = useMemo(() => {
-      if (!props.dataFilters?.filters) return false;
+export const PodEntry = memo<PodItemProps>(function FlowsTableSidebarPodEntry(
+  props,
+) {
+  const onClick = useCallback(() => {
+    props.onClick?.(props.pod);
+  }, [props.pod, props.onClick]);
 
-      return props.dataFilters.filters.some(filter => {
-        return (
-          filter.kind === FlowsFilterKind.Pod &&
-          filter.direction === props.filterDirection &&
-          filter.query === String(props.pod)
-        );
-      });
-    }, [props.dataFilters, props.pod, props.filterDirection]);
+  const className = classnames(css.podd, {
+    [css.clickable]: !!props.onClick,
+    [css.selected]: props.isSelected,
+  });
 
-    const onClick = useCallback(() => {
-      props.onSelectFilters?.({
-        filters: isSelected
-          ? []
-          : [
-              new FlowsFilterEntry({
-                kind: FlowsFilterKind.Pod,
-                direction: props.filterDirection ?? FlowsFilterDirection.Both,
-                query: String(props.pod),
-              }),
-            ],
-      });
-    }, [props.onSelectFilters, props.pod, isSelected]);
-
-    const className = classnames(css.podd, {
-      [css.clickable]: !!props.onSelectFilters,
-      [css.selected]: isSelected,
-    });
-
-    return (
-      <span className={className} onClick={onClick}>
-        {props.pod}
-      </span>
-    );
-  },
-);
+  return (
+    <span className={className} onClick={onClick}>
+      {props.pod}
+    </span>
+  );
+});

--- a/src/components/FlowsTable/__tests__/Sidebar.test.tsx
+++ b/src/components/FlowsTable/__tests__/Sidebar.test.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { FlowsTableSidebar } from '~/components/FlowsTable/Sidebar';
+
 import { Flow } from '~/domain/flows';
 import { HubbleFlow } from '~/domain/hubble';
+import { Filters } from '~/domain/filtering';
+
 import { act, data, fireEvent, React, render } from '~/testing';
 
 interface Expectations {
@@ -58,6 +61,7 @@ const runAppearanceTests = (container: HTMLElement, exps: Expectations) => {
 // 2. Testing that element under `.close` is clickable
 const runTest = (ntest: number, hf: HubbleFlow, exps: Expectations) => {
   const flow = new Flow(hf);
+  const filters = Filters.fromObject(Filters.default());
 
   const onClose = jest.fn(() => void 0);
   describe(`Sidebar: test ${ntest}`, () => {
@@ -65,7 +69,11 @@ const runTest = (ntest: number, hf: HubbleFlow, exps: Expectations) => {
 
     beforeEach(() => {
       container = renderSidebar(
-        <FlowsTableSidebar flow={flow} onClose={onClose}></FlowsTableSidebar>,
+        <FlowsTableSidebar
+          flow={flow}
+          onClose={onClose}
+          filters={filters}
+        ></FlowsTableSidebar>,
       );
     });
 

--- a/src/components/FlowsTable/general.ts
+++ b/src/components/FlowsTable/general.ts
@@ -34,8 +34,3 @@ export const DEFAULT_FLOWS_TABLE_VISIBLE_COLUMNS = new Set<FlowsTableColumnKey>(
 export function getFlowsTableColumnLabel(column: FlowsTableColumnKey) {
   return FlowsTableColumn[column];
 }
-
-export interface FiltersProps {
-  dataFilters?: Filters;
-  onSelectFilters?: (filters: Filters) => void;
-}

--- a/src/components/FlowsTable/index.tsx
+++ b/src/components/FlowsTable/index.tsx
@@ -12,7 +12,6 @@ import { Header } from './Header';
 import { RowRenderer, RowRendererData } from './Row';
 
 import css from './styles.scss';
-import { Filters } from '~/domain/filtering';
 
 export const DEFAULT_TS_UPDATE_DELAY = 2500;
 export { TickerEvents, OnFlowsDiffCount };
@@ -21,8 +20,6 @@ export interface Props extends CommonProps {
   flows: Flow[];
   selectedFlow: Flow | null;
   onSelectFlow?: (flow: Flow | null) => void;
-  onSelectFilters?: (filters: Filters) => void;
-  dataFilters?: Filters;
   ticker?: Ticker<TickerEvents>;
   onFlowsDiffCount?: OnFlowsDiffCount;
 }

--- a/src/domain/filtering/__tests__/filter-flow.test.ts
+++ b/src/domain/filtering/__tests__/filter-flow.test.ts
@@ -4,6 +4,7 @@ import {
   filterFlowUsingBasicEntry,
 } from '~/domain/filtering';
 
+import { Dictionary } from '~/domain/misc';
 import { Verdict } from '~/domain/hubble';
 import {
   Flow,
@@ -11,9 +12,9 @@ import {
   FlowsFilterKind,
   FlowsFilterDirection,
 } from '~/domain/flows';
+
 import * as combinations from '~/utils/iter-tools/combinations';
 import { flows } from '~/testing/data';
-import { Dictionary } from '~/domain/misc';
 
 const testFilterEntry = (
   captionFn: (flowName: string, testNum: number) => string,
@@ -53,171 +54,171 @@ describe('filterFlow', () => {
   const bothHostFlow = new Flow(flows.fromToHost);
 
   test('namespace > matches to source and destination', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       namespace: 'kube-system',
-    };
+    });
 
     const stay = filterFlow(sameNsFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('namespace > doesnt match with source and destination', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       namespace: 'random-123987-ns',
-    };
+    });
 
     const stay = filterFlow(diffNsFlow, filters);
     expect(stay).toBe(false);
   });
 
   test('namespace > matches with source', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       namespace: 'SenderNs',
-    };
+    });
 
     const stay = filterFlow(diffNsFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('namespace > matches with destination', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       namespace: 'ReceiverNs',
-    };
+    });
 
     const stay = filterFlow(diffNsFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches (Forwarded)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterFlow(diffNsFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > doesnt match (Forwarded vs Dropped)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterFlow(diffNsFlow, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match (Forwarded vs Unknown)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterFlow(diffNsFlow, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > matches (Dropped)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterFlow(verdictDropped, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > doesnt match (Dropped vs Forwarded)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterFlow(verdictDropped, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match (Dropped vs Unknown)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterFlow(verdictDropped, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > matches (Unknown)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterFlow(verdictUnknown, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > doesnt match (Unknown vs Forwarded)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterFlow(verdictUnknown, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match (Unknown vs Dropped)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterFlow(verdictUnknown, filters);
     expect(stay).toBe(false);
   });
 
   test('http status > matches (200)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       httpStatus: '200',
-    };
+    });
 
     const stay = filterFlow(flowHttp200, filters);
     expect(stay).toBe(true);
   });
 
   test('http status > doesnt match (400)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       httpStatus: '400',
-    };
+    });
 
     const stay = filterFlow(flowHttp200, filters);
     expect(stay).toBe(false);
   });
 
   test('http status > matches (200+)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       httpStatus: '200+',
-    };
+    });
 
     const stay = filterFlow(flowHttp200, filters);
     expect(stay).toBe(true);
   });
 
   test('http status > matches (100+)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       httpStatus: '100+',
-    };
+    });
 
     const stay = filterFlow(flowHttp200, filters);
     expect(stay).toBe(true);
   });
 
   test('http status > doesnt match (0)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       httpStatus: '0',
-    };
+    });
 
     const stay = filterFlow(flowHttp200, filters);
     expect(stay).toBe(false);
   });
 
   test('http status > doesnt match (l7 not presented)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       httpStatus: '200',
-    };
+    });
 
     const stay = filterFlow(sameNsFlow, filters);
     expect(stay).toBe(false);
@@ -241,72 +242,72 @@ describe('filterFlow', () => {
   // they are just visual (service) filters and should be violate
   // data on flows table
   test('skip kube dns > flow not skipped 1', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: true,
-    };
+    });
 
     const stay = filterFlow(flows.normalOne, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 2', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: false,
-    };
+    });
 
     const stay = filterFlow(flows.normalOne, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 3', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: true,
-    };
+    });
 
     const stay = filterFlow(toKubeDNSFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 4', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: false,
-    };
+    });
 
     const stay = filterFlow(toKubeDNSFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 5', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: true,
-    };
+    });
 
     const stay = filterFlow(fromKubeDNSFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 6', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: false,
-    };
+    });
 
     const stay = filterFlow(fromKubeDNSFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 7', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: true,
-    };
+    });
 
     const stay = filterFlow(bothKubeDNSFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip kube dns > flow not skipped 8', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: false,
-    };
+    });
 
     const stay = filterFlow(bothKubeDNSFlow, filters);
     expect(stay).toBe(true);
@@ -327,72 +328,72 @@ describe('filterFlow', () => {
   });
 
   test('skip host > flow not skipped 1', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: true,
-    };
+    });
 
     const stay = filterFlow(flows.normalOne, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 2', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: false,
-    };
+    });
 
     const stay = filterFlow(flows.normalOne, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 3', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: true,
-    };
+    });
 
     const stay = filterFlow(fromHostFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 4', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: false,
-    };
+    });
 
     const stay = filterFlow(fromHostFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 5', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: true,
-    };
+    });
 
     const stay = filterFlow(toHostFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 6', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: false,
-    };
+    });
 
     const stay = filterFlow(toHostFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 7', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: true,
-    };
+    });
 
     const stay = filterFlow(bothHostFlow, filters);
     expect(stay).toBe(true);
   });
 
   test('skip host > flow not skipped 8', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: false,
-    };
+    });
 
     const stay = filterFlow(bothHostFlow, filters);
     expect(stay).toBe(true);

--- a/src/domain/filtering/__tests__/filter-link.test.ts
+++ b/src/domain/filtering/__tests__/filter-link.test.ts
@@ -1,5 +1,6 @@
 import {
   Filters,
+  FiltersObject,
   filterLink,
   filterLinkUsingBasicEntry,
 } from '~/domain/filtering';
@@ -10,15 +11,18 @@ import { Flow, FlowsFilterEntry } from '~/domain/flows';
 import { Dictionary } from '~/domain/misc';
 import { links } from '~/testing/data';
 
-const runUnusedFiltersTests = (filters: Filters[], links: Dictionary<Link>) => {
+const runUnusedFiltersTests = (
+  filters: FiltersObject[],
+  links: Dictionary<Link>,
+) => {
   Object.keys(links).forEach((linkName: string) => {
     const link = links[linkName];
 
-    filters.forEach((f: Filters, fidx: number) => {
+    filters.forEach((f: FiltersObject, fidx: number) => {
       test(`unused filter fields test, link: ${linkName}, filters: ${
         fidx + 1
       }`, () => {
-        const stay = filterLink(link, f);
+        const stay = filterLink(link, Filters.fromObject(f));
         expect(stay).toBe(true);
       });
     });
@@ -53,162 +57,162 @@ describe('filterLink', () => {
   const { tcpForwardedDropped, tcpMixed } = links;
 
   test('verdict > matches 1', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterLink(tcpForwarded, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 2', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterLink(tcpDropped, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 3', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Error,
-    };
+    });
 
     const stay = filterLink(tcpError, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 4', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterLink(tcpUnknown, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 5', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterLink(tcpForwardedDropped, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 6', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterLink(tcpForwardedDropped, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 7', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterLink(tcpMixed, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 8', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterLink(tcpMixed, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 9', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Error,
-    };
+    });
 
     const stay = filterLink(tcpMixed, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > matches 10', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterLink(tcpMixed, filters);
     expect(stay).toBe(true);
   });
 
   test('verdict > doesnt match 1', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Forwarded,
-    };
+    });
 
     const stay = filterLink(tcpDropped, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 2', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterLink(tcpDropped, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 3', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Error,
-    };
+    });
 
     const stay = filterLink(tcpDropped, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 4', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Dropped,
-    };
+    });
 
     const stay = filterLink(tcpForwarded, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 5', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterLink(tcpForwarded, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 6', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Error,
-    };
+    });
 
     const stay = filterLink(tcpForwarded, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 7', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Error,
-    };
+    });
 
     const stay = filterLink(tcpForwardedDropped, filters);
     expect(stay).toBe(false);
   });
 
   test('verdict > doesnt match 8', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       verdict: Verdict.Unknown,
-    };
+    });
 
     const stay = filterLink(tcpForwardedDropped, filters);
     expect(stay).toBe(false);

--- a/src/domain/filtering/__tests__/filter-service.test.ts
+++ b/src/domain/filtering/__tests__/filter-service.test.ts
@@ -1,5 +1,6 @@
 import {
   Filters,
+  FiltersObject,
   filterService,
   filterServiceUsingBasicEntry,
 } from '~/domain/filtering';
@@ -17,17 +18,17 @@ import {
 import { expectFilterEntry } from './general';
 
 const runUnusedFiltersTests = (
-  filters: Filters[],
+  filters: FiltersObject[],
   services: Dictionary<ServiceCard>,
 ) => {
   Object.keys(services).forEach((linkName: string) => {
     const service = services[linkName];
 
-    filters.forEach((f: Filters, fidx: number) => {
+    filters.forEach((f: FiltersObject, fidx: number) => {
       test(`unused filter fields test, service: ${linkName}, filters: ${
         fidx + 1
       }`, () => {
-        const stay = filterService(service, f);
+        const stay = filterService(service, Filters.fromObject(f));
         expect(stay).toBe(true);
       });
     });
@@ -166,63 +167,63 @@ describe('filterService', () => {
   });
 
   test('host > doesnt match (skipHost = true)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: true,
-    };
+    });
 
     const stay = filterService(host, filters);
     expect(stay).toBe(false);
   });
 
   test('host > matches (skipHost = false)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: false,
-    };
+    });
 
     const stay = filterService(host, filters);
     expect(stay).toBe(true);
   });
 
   test('host > matches (skipKubeDns = true)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: true,
-    };
+    });
 
     const stay = filterService(host, filters);
     expect(stay).toBe(true);
   });
 
   test('kubeDns > matches (skipHost = true)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: true,
-    };
+    });
 
     const stay = filterService(kubeDns, filters);
     expect(stay).toBe(true);
   });
 
   test('kubeDns > matches (skipHost = false)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipHost: false,
-    };
+    });
 
     const stay = filterService(kubeDns, filters);
     expect(stay).toBe(true);
   });
 
   test('kubeDns > matches (skipKubeDns = false)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: false,
-    };
+    });
 
     const stay = filterService(kubeDns, filters);
     expect(stay).toBe(true);
   });
 
   test('kubeDns > doesnt match (skipKubeDns = true)', () => {
-    const filters: Filters = {
+    const filters: Filters = Filters.fromObject({
       skipKubeDns: true,
-    };
+    });
 
     const stay = filterService(kubeDns, filters);
     expect(stay).toBe(false);

--- a/src/domain/filtering/__tests__/filters-equality.test.ts
+++ b/src/domain/filtering/__tests__/filters-equality.test.ts
@@ -1,4 +1,4 @@
-import { Filters, areFiltersEqual } from '~/domain/filtering';
+import { Filters } from '~/domain/filtering';
 import { FlowsFilterEntry } from '~/domain/flows';
 import { Verdict } from '~/domain/hubble';
 
@@ -45,6 +45,8 @@ const testCommonFiltersEquality = () => {
 
   const skipHosts: Array<undefined | boolean> = [undefined, false, true];
   const skipKubeDnss: Array<undefined | boolean> = [undefined, false, true];
+  const skipRemoteApps: Array<undefined | boolean> = [undefined, false, true];
+  const skipPrometheusApps = [undefined, false, true];
 
   combinations
     .arrays([
@@ -54,34 +56,50 @@ const testCommonFiltersEquality = () => {
       filters.length,
       skipHosts.length,
       skipKubeDnss.length,
+      skipRemoteApps.length,
+      skipPrometheusApps.length,
     ])
     .forEach((indices: number[], idx: number) => {
-      const [nsIdx, verdictIdx, hsIdx, filtersIdx, shIdx, skdIdx] = indices;
-      const aFilters: Filters = {
+      const [
+        nsIdx,
+        verdictIdx,
+        hsIdx,
+        filtersIdx,
+        shIdx,
+        skdIdx,
+        skrIdx,
+        skpaIdx,
+      ] = indices;
+
+      const aFilters: Filters = Filters.fromObject({
         namespace: namespaces[nsIdx],
         verdict: verdicts[verdictIdx],
         httpStatus: httpStatuses[hsIdx],
         filters: filters[filtersIdx],
         skipHost: skipHosts[shIdx],
         skipKubeDns: skipKubeDnss[skdIdx],
-      };
+        skipRemoteNode: skipRemoteApps[skrIdx],
+        skipPrometheusApp: skipPrometheusApps[skpaIdx],
+      });
 
-      const bFilters: Filters = {
+      const bFilters: Filters = Filters.fromObject({
         namespace: nextElem(nsIdx, namespaces),
         verdict: nextElem(verdictIdx, verdicts),
         httpStatus: nextElem(hsIdx, httpStatuses),
         filters: nextElem(filtersIdx, filters),
         skipHost: nextElem(shIdx, skipHosts),
         skipKubeDns: nextElem(skdIdx, skipKubeDnss),
-      };
+        skipRemoteNode: nextElem(skrIdx, skipRemoteApps),
+        skipPrometheusApp: nextElem(skpaIdx, skipPrometheusApps),
+      });
 
       test(`test ${idx * 2 + 1} > self-equality`, () => {
-        const sameFilters = Object.assign({}, aFilters);
-        expect(areFiltersEqual(aFilters, sameFilters)).toBe(true);
+        const sameFilters = aFilters.clone();
+        expect(aFilters.equals(sameFilters)).toBe(true);
       });
 
       test(`test ${idx * 2 + 2} > inequality`, () => {
-        expect(areFiltersEqual(aFilters, bFilters)).toBe(false);
+        expect(aFilters.equals(bFilters)).toBe(false);
       });
     });
 };

--- a/src/domain/filtering/filters.ts
+++ b/src/domain/filtering/filters.ts
@@ -1,0 +1,125 @@
+import { FlowsFilterEntry, Verdict } from '~/domain/flows';
+
+const assignFilterProps = (to: FiltersObject, from: FiltersObject) => {
+  Object.assign(to, {
+    namespace: from.namespace,
+    verdict: from.verdict,
+    httpStatus: from.httpStatus,
+    filters: from.filters,
+    skipHost: from.skipHost,
+    skipKubeDns: from.skipKubeDns,
+    skipRemoteNode: from.skipRemoteNode,
+    skipPrometheusApp: from.skipPrometheusApp,
+  });
+
+  return to;
+};
+
+export interface FiltersObject {
+  namespace?: string | null;
+  verdict?: Verdict | null;
+  httpStatus?: string | null;
+  filters?: FlowsFilterEntry[];
+  skipHost?: boolean;
+  skipKubeDns?: boolean;
+  skipRemoteNode?: boolean;
+  skipPrometheusApp?: boolean;
+}
+
+const defaultFilters: FiltersObject = Object.freeze({
+  namespace: null,
+  verdict: null,
+  httpStatus: null,
+  filters: [],
+  skipHost: true,
+  skipKubeDns: true,
+  skipRemoteNode: true,
+  skipPrometheusApp: true,
+});
+
+export class Filters implements FiltersObject {
+  public namespace?: string | null;
+  public verdict?: Verdict | null;
+  public httpStatus?: string | null;
+  public filters?: FlowsFilterEntry[];
+  public skipHost?: boolean;
+  public skipKubeDns?: boolean;
+  public skipRemoteNode?: boolean;
+  public skipPrometheusApp?: boolean;
+
+  public static fromObject(obj: FiltersObject): Filters {
+    return new Filters(obj);
+  }
+
+  public static default(): FiltersObject {
+    return defaultFilters;
+  }
+
+  constructor(obj: FiltersObject) {
+    assignFilterProps(this, obj);
+  }
+
+  public setNamespace(ns: string | null) {
+    this.namespace = ns;
+
+    return this;
+  }
+
+  public toPlainObject(): FiltersObject {
+    return assignFilterProps({} as FiltersObject, this);
+  }
+
+  public equals(rhs: FiltersObject): boolean {
+    if (
+      this.namespace != rhs.namespace ||
+      this.verdict != rhs.verdict ||
+      this.httpStatus != rhs.httpStatus ||
+      this.skipHost != rhs.skipHost ||
+      this.skipKubeDns != rhs.skipKubeDns ||
+      this.skipRemoteNode != rhs.skipRemoteNode ||
+      this.skipPrometheusApp != rhs.skipPrometheusApp
+    ) {
+      return false;
+    }
+
+    const aEntries = (this.filters || []).reduce((acc, f) => {
+      acc.add(f.toString());
+      return acc;
+    }, new Set());
+
+    const bEntries = (rhs.filters || []).reduce((acc, f) => {
+      acc.add(f.toString());
+      return acc;
+    }, new Set());
+
+    if (aEntries.size !== bEntries.size) return false;
+
+    for (const f of aEntries) {
+      if (!bEntries.has(f)) return false;
+    }
+
+    return true;
+  }
+
+  public clone(deep = false): Filters {
+    const shallowObj: FiltersObject = this.toPlainObject();
+
+    if (deep) {
+      shallowObj.filters = (shallowObj.filters || []).map(f => f.clone());
+    }
+
+    return Filters.fromObject(shallowObj);
+  }
+
+  public get isDefault(): boolean {
+    return (
+      this.verdict == defaultFilters.verdict &&
+      this.httpStatus == defaultFilters.httpStatus &&
+      (this.filters == null || this.filters.length === 0) &&
+      !!this.skipHost === defaultFilters.skipHost &&
+      !!this.skipKubeDns === defaultFilters.skipKubeDns &&
+      !!this.skipRemoteNode === defaultFilters.skipRemoteNode &&
+      !!this.skipPrometheusApp === defaultFilters.skipPrometheusApp
+    );
+  }
+}

--- a/src/domain/filtering/index.ts
+++ b/src/domain/filtering/index.ts
@@ -8,48 +8,9 @@ import {
 
 import { Link, Service } from '~/domain/service-map';
 import { ServiceCard } from '~/domain/service-card';
+import { Filters, FiltersObject } from './filters';
 
-export interface Filters {
-  namespace?: string | null;
-  verdict?: Verdict | null;
-  httpStatus?: string | null;
-  filters?: FlowsFilterEntry[];
-  skipHost?: boolean;
-  skipKubeDns?: boolean;
-  skipRemoteNode?: boolean;
-  skipPrometheusApp?: boolean;
-}
-
-export const areFiltersEqual = (a: Filters, b: Filters): boolean => {
-  if (
-    a.namespace != b.namespace ||
-    a.verdict != b.verdict ||
-    a.httpStatus != b.httpStatus ||
-    a.skipHost != b.skipHost ||
-    a.skipKubeDns != b.skipKubeDns ||
-    a.skipRemoteNode != b.skipRemoteNode ||
-    a.skipPrometheusApp != b.skipPrometheusApp
-  )
-    return false;
-
-  const aEntries = (a.filters || []).reduce((acc, f) => {
-    acc.add(f.toString());
-    return acc;
-  }, new Set());
-
-  const bEntries = (b.filters || []).reduce((acc, f) => {
-    acc.add(f.toString());
-    return acc;
-  }, new Set());
-
-  if (aEntries.size !== bEntries.size) return false;
-
-  for (const f of aEntries) {
-    if (!bEntries.has(f)) return false;
-  }
-
-  return true;
-};
+export { Filters, FiltersObject };
 
 export const filterFlow = (flow: Flow, filters: Filters): boolean => {
   if (filters.namespace != null) {

--- a/src/domain/flows/flows-filter-entry.ts
+++ b/src/domain/flows/flows-filter-entry.ts
@@ -141,6 +141,60 @@ export class FlowsFilterEntry {
     }
   }
 
+  public static newTCPFlag(flag: string): FlowsFilterEntry {
+    return new FlowsFilterEntry({
+      kind: FlowsFilterKind.TCPFlag,
+      query: flag,
+      direction: FlowsFilterDirection.Both,
+      meta: '',
+    });
+  }
+
+  public static newLabel(label: string): FlowsFilterEntry {
+    return new FlowsFilterEntry({
+      kind: FlowsFilterKind.Label,
+      query: label,
+      direction: FlowsFilterDirection.Both,
+      meta: '',
+    });
+  }
+
+  public static newPod(podName: string): FlowsFilterEntry {
+    return new FlowsFilterEntry({
+      kind: FlowsFilterKind.Pod,
+      query: podName,
+      direction: FlowsFilterDirection.Both,
+      meta: '',
+    });
+  }
+
+  public static newIdentity(identity: string): FlowsFilterEntry {
+    return new FlowsFilterEntry({
+      kind: FlowsFilterKind.Identity,
+      query: identity,
+      direction: FlowsFilterDirection.Both,
+      meta: '',
+    });
+  }
+
+  public static newDNS(dns: string): FlowsFilterEntry {
+    return new FlowsFilterEntry({
+      kind: FlowsFilterKind.Dns,
+      query: dns,
+      direction: FlowsFilterDirection.Both,
+      meta: '',
+    });
+  }
+
+  public static newIP(ip: string): FlowsFilterEntry {
+    return new FlowsFilterEntry({
+      kind: FlowsFilterKind.Ip,
+      query: ip,
+      direction: FlowsFilterDirection.Both,
+      meta: '',
+    });
+  }
+
   constructor({ kind, direction, query, meta }: Params) {
     this.kind = kind;
     this.query = query;
@@ -158,6 +212,24 @@ export class FlowsFilterEntry {
     return this;
   }
 
+  public setQuery(q: string): FlowsFilterEntry {
+    this.query = q;
+
+    return this;
+  }
+
+  public setDirection(dir: FlowsFilterDirection): FlowsFilterEntry {
+    this.direction = dir;
+
+    return this;
+  }
+
+  public setKind(kind: FlowsFilterKind): FlowsFilterEntry {
+    this.kind = kind;
+
+    return this;
+  }
+
   public toString(): string {
     return `${this.direction}:${this.kind}=${this.query}`;
   }
@@ -169,6 +241,14 @@ export class FlowsFilterEntry {
       query: this.query,
       meta: this.meta,
     });
+  }
+
+  public equals(rhs: FlowsFilterEntry): boolean {
+    return (
+      this.kind === rhs.kind &&
+      this.direction === rhs.direction &&
+      this.query === rhs.query
+    );
   }
 
   public get isDNS(): boolean {
@@ -189,6 +269,10 @@ export class FlowsFilterEntry {
 
   public get isTCPFlag(): boolean {
     return this.kind === FlowsFilterKind.TCPFlag;
+  }
+
+  public get isPod(): boolean {
+    return this.kind === FlowsFilterKind.Pod;
   }
 
   public get labelKeyValue(): [string, string] {

--- a/src/domain/hubble.ts
+++ b/src/domain/hubble.ts
@@ -138,6 +138,8 @@ export interface TCPFlags {
   ns: boolean;
 }
 
+export type TCPFlagName = keyof TCPFlags;
+
 export interface IP {
   source: string;
   destination: string;

--- a/src/domain/labels.ts
+++ b/src/domain/labels.ts
@@ -1,4 +1,5 @@
 import { KV } from '~/domain/misc';
+export { KV };
 
 export interface LabelsProps {
   isHost: boolean;
@@ -53,6 +54,12 @@ export class Labels {
     let str = Labels.normalizeKey(label.key);
     if (label.value) str += `=${label.value}`;
     return str;
+  }
+
+  public static concatKV(label: KV, normalize = false): string {
+    const key = normalize ? Labels.normalizeKey(label.key) : label.key;
+
+    return `${key}${label.value ? `=${label.value}` : ''}`;
   }
 
   public static findLabelNameByNormalizedKey(

--- a/src/store/stores/controls.ts
+++ b/src/store/stores/controls.ts
@@ -162,8 +162,8 @@ export default class ControlStore {
   }
 
   @computed
-  get dataFilters(): Required<Filters> {
-    return {
+  get filters(): Filters {
+    return Filters.fromObject({
       namespace: this.currentNamespace,
       verdict: this.verdict,
       httpStatus: this.httpStatus,
@@ -172,30 +172,17 @@ export default class ControlStore {
       skipKubeDns: !this.showKubeDns,
       skipRemoteNode: !this.showRemoteNode,
       skipPrometheusApp: !this.showPrometheusApp,
-    };
+    });
   }
 
   @computed
-  get mainFilters() {
-    return {
+  get mainFilters(): Filters {
+    return Filters.fromObject({
       namespace: this.currentNamespace,
       skipHost: !this.showHost,
       skipKubeDns: !this.showKubeDns,
       skipRemoteNode: !this.showRemoteNode,
       skipPrometheusApp: !this.showPrometheusApp,
-    };
-  }
-
-  @computed
-  get isDefault(): boolean {
-    return (
-      this.verdict == null &&
-      this.httpStatus == null &&
-      this.flowFilters.length === 0 &&
-      !this.showHost &&
-      !this.showKubeDns &&
-      !this.showRemoteNode &&
-      !this.showPrometheusApp
-    );
+    });
   }
 }


### PR DESCRIPTION
* fix: `SidebarComponents` now have centralized logic, moved to parent component
* feat: `Filters` is now separate class with convenient methods
* fix: API now depends on domain `Filters` type instead of its own `DataFilters`, which was removed