### PR TITLE
api: setSince to last 5 minutes and follow request

### DIFF
--- a/src/api/grpc/event-stream.ts
+++ b/src/api/grpc/event-stream.ts
@@ -30,6 +30,7 @@ import {
 import { GeneralStreamEventKind } from '~/api/general/stream';
 
 import EventCase = GetEventsResponse.EventCase;
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 type GRPCEventStream = ClientReadableStream<GetEventsResponse>;
 type FlowFilters = [FlowFilter[], FlowFilter[]];
@@ -83,6 +84,13 @@ export class EventStream extends EventEmitter<EventStreamHandlers>
 
     req.setWhitelistList(wlFilters);
     req.setBlacklistList(blFilters);
+
+    // requests flows for last 5 minutes
+    const last5Min = new Date(new Date().valueOf() - 1000 * 60 * 5).getTime();
+    const last5MinTimestamp = new Timestamp();
+    last5MinTimestamp.setSeconds(Math.trunc(last5Min / 1000));
+    last5MinTimestamp.setNanos(Math.trunc((last5Min & 1000) * 1e6));
+    req.setSince(last5MinTimestamp);
 
     return req;
   }


### PR DESCRIPTION
Make hubble-ui requests last 5 minutes of available data in hubble buffer.

Signed-off-by: Sergey Generalov <sergey@genbit.ru>