### PR TITLE
fix: do not unblock for/select loop in GetEvents

### DIFF
--- a/backend/server/get-events.go
+++ b/backend/server/get-events.go
@@ -174,8 +174,6 @@ F:
 				log.Errorf(msg.SendHubbleStatusError, err)
 				return err
 			}
-		default:
-			break
 		}
 	}
 


### PR DESCRIPTION
This fix prevents `GetEvents` server method from eating cpu for 100%