### PR TITLE
Dockerfile: use alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} docker.io/library/node:15.14.0-alpine3.13@sha256:01adde22c684b850fc66d9ad2211ff280b303a3d194edf7edba8ab0870bb9b1e as stage1
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:15.14.0-alpine3.12@sha256:0b0c5112216cdbacf8a2e55b075c411ef1c726eb6913796b4bfc72237aa5ac58 as stage1
 RUN apk add bash
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ COPY ./build-gops.sh .
 RUN --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
     ./build-gops.sh
 
-FROM docker.io/library/alpine:3.13.5@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f
+FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
In Alpine 3.11 and 3.13, 'nslookup' exits with the error code 1 if it
can't resolve all IPs for the search list defined in /etc/resolv.conf

However, it seems that Alpine 3.10 and 3.12 are not affected by this bug
and continue return the error code 0 if at least on of the domains in
the search list is resolved into an IP address. Thus, we will use the
latest Alpine image available for the 3.12 release series.

Signed-off-by: André Martins <andre@cilium.io>