### PR TITLE
Make sure Go backend recognised `app.kubernetes.io` labels also

### DIFF
--- a/backend/domain/labels/labels.go
+++ b/backend/domain/labels/labels.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	prefixes = []string{"k8s:", "io.kubernetes.pod."}
+	prefixes = []string{"k8s:", "io.kubernetes.pod.", "app.kubernetes.io/"}
 	appKeys  = []string{"app", "name", "functionName", "k8s-app"}
 )
 


### PR DESCRIPTION
These labels were added in ce76f206d8b7bb8d23a945b5d93c879de8d9bff2,
but only in TypeScript code and not the Go version.