### PR TITLE
feat: Add ICMP info on Service Map and Flows Table

### DIFF
--- a/src/api/grpc/common.ts
+++ b/src/api/grpc/common.ts
@@ -89,13 +89,6 @@ export const buildBlacklistFlowFilters = (filters?: Filters): FlowFilter[] => {
   blDstLocalDnsFilter.addDestinationFqdn('*.cluster.local*');
   blFilters.push(blSrcLocalDnsFilter, blDstLocalDnsFilter);
 
-  // filter out icmp flows
-  const blICMPv4Filter = new FlowFilter();
-  const blICMPv6Filter = new FlowFilter();
-  blICMPv4Filter.addProtocol('ICMPv4');
-  blICMPv6Filter.addProtocol('ICMPv6');
-  blFilters.push(blICMPv4Filter, blICMPv6Filter);
-
   return blFilters;
 };
 

--- a/src/components/AccessPoint/index.tsx
+++ b/src/components/AccessPoint/index.tsx
@@ -17,7 +17,7 @@ export interface Props {
   onConnectorCoords?: (_: XY) => void;
 }
 
-export const Component: FunctionComponent<Props> = props => {
+export function AccessPointComponent(props: Props) {
   const imgContainer = useRef<HTMLDivElement>(null);
 
   const handle = useElemCoords(imgContainer, false, coords => {
@@ -27,6 +27,13 @@ export const Component: FunctionComponent<Props> = props => {
   useDiff(props.indicator?.value, () => {
     handle.emit();
   });
+
+  const showPort =
+    props.l4Protocol !== IPProtocol.ICMPv4 &&
+    props.l4Protocol !== IPProtocol.ICMPv6;
+
+  const showL7Protocol =
+    props.l7Protocol != null && props.l7Protocol !== L7Kind.Unknown;
 
   return (
     <div className={css.accessPoint}>
@@ -41,11 +48,15 @@ export const Component: FunctionComponent<Props> = props => {
       </div>
 
       <div className={css.data}>
-        <div className={css.port}>{props.port}</div>
-        <div className={css.dot} />
+        {showPort && (
+          <>
+            <div className={css.port}>{props.port}</div>
+            <div className={css.dot} />
+          </>
+        )}
         <div className={css.protocol}>{IPProtocol[props.l4Protocol]}</div>
 
-        {props.l7Protocol != null && props.l7Protocol !== L7Kind.Unknown && (
+        {props.l7Protocol && showL7Protocol && (
           <>
             <div className={css.dot} />
             <div className={css.protocol}>
@@ -56,6 +67,6 @@ export const Component: FunctionComponent<Props> = props => {
       </div>
     </div>
   );
-};
+}
 
-export const AccessPoint = React.memo(Component);
+export const AccessPoint = React.memo(AccessPointComponent);

--- a/src/components/FlowsTable/Sidebar.tsx
+++ b/src/components/FlowsTable/Sidebar.tsx
@@ -3,7 +3,7 @@ import React, { memo, useCallback, useMemo, useEffect, useState } from 'react';
 
 import { Flow, Verdict } from '~/domain/flows';
 import { Filters, FilterEntry, FilterDirection } from '~/domain/filtering';
-import { TCPFlagName, PodSelector } from '~/domain/hubble';
+import { TCPFlagName, PodSelector, IPProtocol } from '~/domain/hubble';
 import { KV, Labels } from '~/domain/labels';
 
 import {
@@ -36,6 +36,7 @@ export const FlowsTableSidebar = memo<Props>(function FlowsTableSidebar(props) {
 
   const tcpFilterDirection = FilterDirection.From;
   const isVerdictSelected = props.filters.verdict === flow.verdict;
+  const protocol = props.flow.protocolStr;
 
   const onVerdictClick = useCallback(() => {
     props.onVerdictClick?.(isVerdictSelected ? null : flow.verdict);
@@ -274,6 +275,10 @@ export const FlowsTableSidebar = memo<Props>(function FlowsTableSidebar(props) {
     props.onDnsClick?.(props.flow.destinationDns);
   }, [props.flow, props.onDnsClick, isDnsSelected]);
 
+  const isICMPProtocol =
+    props.flow.protocol === IPProtocol.ICMPv4 ||
+    props.flow.protocol === IPProtocol.ICMPv6;
+
   return (
     <div className={css.sidebar}>
       <header className={css.header}>
@@ -433,10 +438,15 @@ export const FlowsTableSidebar = memo<Props>(function FlowsTableSidebar(props) {
           </div>
         </section>
       )}
-      {flow.hasDestination && typeof flow.destinationPort === 'number' && (
+      {flow.hasDestination && flow.protocol && (
         <section className={css.block}>
-          <span className={css.title}>Destination port</span>
-          <div className={css.body}>{flow.destinationPort}</div>
+          <span className={css.title}>
+            Destination {!isICMPProtocol && 'port • '}protocol
+          </span>
+          <div className={css.body}>
+            {flow.destinationPort && `${flow.destinationPort} • `}
+            {protocol && `${protocol}`}
+          </div>
         </section>
       )}
     </div>

--- a/src/components/FlowsTable/__tests__/Sidebar.test.tsx
+++ b/src/components/FlowsTable/__tests__/Sidebar.test.tsx
@@ -117,18 +117,30 @@ runTest(5, data.flows.hubbleOne, {
   body: 'app=Receivernamespace=ReceiverNs',
 });
 
-// `Destination labels` info renders
+// `Destination labels` Non-ICMP info renders
 runTest(6, data.flows.hubbleOne, {
-  title: 'Destination port',
-  body: '80',
+  title: 'Destination port • protocol',
+  body: '80 • TCP',
+});
+
+// `Destination labels` ICMPv4 info renders
+runTest(7, data.flows.icmpv4Flow, {
+  title: 'Destination protocol',
+  body: 'ICMPv4',
+});
+
+// `Destination labels` ICMPv6 info renders
+runTest(8, data.flows.icmpv6Flow, {
+  title: 'Destination protocol',
+  body: 'ICMPv6',
 });
 
 // `Destination DNS` info doesn't render when unavailable
-runTest(7, data.flows.hubbleOne, {
+runTest(9, data.flows.hubbleOne, {
   title: 'Destination DNS',
 });
 
 // `Destination IP` info doesn't render when unavailable
-runTest(8, data.flows.hubbleOne, {
+runTest(10, data.flows.hubbleOne, {
   title: 'Destination IP',
 });

--- a/src/testing/data/flows.ts
+++ b/src/testing/data/flows.ts
@@ -13,6 +13,52 @@ import { SpecialLabel, ReservedLabel } from '~/domain/labels';
 
 const nowMs = Date.now();
 
+export const icmpv4Flow: HubbleFlow = {
+  verdict: Verdict.Forwarded,
+  dropReason: 0,
+  l4: {
+    icmpv4: {
+      type: 0,
+      code: 0,
+    },
+  },
+  source: {
+    id: 0,
+    identity: 0,
+    labelsList: ['app=Sender', 'namespace=SenderNs'],
+    namespace: 'SenderNs',
+    podName: `sender-a1b2c3`,
+  },
+  destination: {
+    id: 1,
+    identity: 1,
+    labelsList: ['app=Receiver', 'namespace=ReceiverNs'],
+    namespace: 'ReceiverNs',
+    podName: `receiver-d4e5f6`,
+  },
+  sourceNamesList: [],
+  destinationNamesList: [],
+  nodeName: 'TestNode',
+  reply: false,
+  summary: '',
+  type: FlowType.L34,
+  time: {
+    seconds: nowMs / 1000,
+    nanos: nowMs * 1000000,
+  },
+  trafficDirection: TrafficDirection.Ingress,
+};
+
+export const icmpv6Flow: HubbleFlow = {
+  ...icmpv4Flow,
+  l4: {
+    icmpv6: {
+      code: 0,
+      type: 0,
+    },
+  },
+};
+
 export const hubbleOne: HubbleFlow = {
   verdict: Verdict.Forwarded,
   dropReason: 0,


### PR DESCRIPTION
This change adds ICMP information to the Service Map and Flows Table. 

It also improves the Destination Port and Protocol section in the Flows Sidebar. This conditionally renders the port and protocol's titles and content based on whether a flow's protocol is ICMP. Relevant tests are included.

Fixes: [#276](https://github.com/cilium/hubble-ui/issues/276)

Signed-off-by: Stacy Kim <stacy.kim@ucla.edu>