### PR TITLE
backend: Shut down HTTP Server when receiving signal

### DIFF
--- a/backend/internal/msg/logs.go
+++ b/backend/internal/msg/logs.go
@@ -18,6 +18,7 @@ const (
 	ServerSetupUsingDefRelayAddr   = "hubble-relay addr is set to default (%s)\n"
 	ServerSetupUsingDefPort        = "server port is set to default (%s)\n"
 	ServerSetupListeningAt         = "listening at: %s\n"
+	ServerSetupShuttingDown        = "shutting down http server after receiving signal\n"
 	ServerSetupConfigInitError     = "failed to initialize hubble-ui backend: %s\n"
 	ServerSetupTLSAllowInsecureDef = "TLSAllowInsecure option set to: %v\n"
 	ServerSetupTLSInitWithNCACerts = "initialized with %d CA certificates\n"

--- a/backend/main.go
+++ b/backend/main.go
@@ -71,7 +71,7 @@ func runServer(cfg *config.Config) {
 
 	go func() {
 		<-ctx.Done()
-		log.Info("Received signal. Shutting down server")
+		log.Info(msg.ServerSetupShuttingDown)
 
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()


### PR DESCRIPTION
This PR addresses #360 that was raised by my colleague @saichovsky.

In this PR, I added the necessary code to handle the case where a SIGINT or SIGTERM is sent to the backend app. 

