### PR TITLE
frontend: support negative flow filter

### DIFF
--- a/src/components/TopBar/FlowsFilterInput.scss
+++ b/src/components/TopBar/FlowsFilterInput.scss
@@ -92,6 +92,11 @@
       display: block;
     }
 
+    .negative {
+      color: #d00;
+      margin: 0 2px;
+    }
+
     .kind {
       color: #3b3c42;
     }

--- a/src/components/TopBar/FlowsFilterInput.tsx
+++ b/src/components/TopBar/FlowsFilterInput.tsx
@@ -128,6 +128,7 @@ function tagRenderer(item: FilterEntry | null) {
     <div className={css.tag}>
       <TagDirection direction={item.direction} />
       <span className={css.body}>
+        {item.negative && <span className={css.negative}>!</span>}
         <span className={css.kind}>{item.kind}</span>
         <span className={css.separator}>=</span>
         <span className={css.query}>{query}</span>

--- a/src/domain/filtering/__tests__/filter-entry.test.ts
+++ b/src/domain/filtering/__tests__/filter-entry.test.ts
@@ -7,6 +7,7 @@ const parse = (
   dir: FilterDirection,
   kind: FilterKind,
   query: string,
+  negative = false,
 ) => {
   test(testName, () => {
     const e = FilterEntry.parse(s);
@@ -17,6 +18,7 @@ const parse = (
     expect(e!.kind).toBe(kind);
     expect(e!.direction).toBe(dir);
     expect(e!.query).toBe(query);
+    expect(e!.negative).toBe(negative);
   });
 };
 
@@ -181,5 +183,15 @@ describe('correct strings parsing', () => {
     FilterDirection.Both,
     FilterKind.Pod,
     'random',
+  );
+
+  parse(
+    'correct 20',
+    '!pod=random',
+    true,
+    FilterDirection.Both,
+    FilterKind.Pod,
+    'random',
+    true,
   );
 });

--- a/src/domain/filtering/__tests__/filter-flow.test.ts
+++ b/src/domain/filtering/__tests__/filter-flow.test.ts
@@ -1017,4 +1017,177 @@ describe('filterFlow', () => {
       fromSenderToSenderPod,
     },
   );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > from label matches ${tnum} (${flowName})`,
+    FilterEntry.parse(`!from:label=namespace=SenderNs`)!,
+    false,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      flowHttp200,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > from label doesnt match ${tnum} (${flowName})`,
+    FilterEntry.parse(`!from:label=namespace=SenderNs`)!,
+    true,
+    {
+      sameNsFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > both dns matches ${tnum} (${flowName})`,
+    FilterEntry.parse(`!both:dns=www.google.com`)!,
+    false,
+    {
+      toGoogleFlow,
+      fromGoogleFlow,
+      bothGoogleFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > both dns doesnt match ${tnum} (${flowName})`,
+    FilterEntry.parse(`!both:dns=www.google.com`)!,
+    true,
+    {
+      diffNsFlow,
+      differentIpsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameIpsFlow,
+      sameV6IpsFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > both identity matches ${tnum} (${flowName})`,
+    FilterEntry.parse(`!both:identity=1`)!,
+    false,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > both identity doesnt match ${tnum} (${flowName})`,
+    FilterEntry.parse(`!both:identity=100500`)!,
+    true,
+    {
+      normalOne: flows.normalOne,
+      differentIpsFlow,
+      sameIpsFlow,
+      diffNsFlow,
+      verdictDropped,
+      verdictUnknown,
+      sameV6IpsFlow,
+      fromGoogleFlow,
+      toGoogleFlow,
+      bothGoogleFlow,
+      toKubeDNSFlow,
+      fromKubeDNSFlow,
+      bothKubeDNSFlow,
+      fromHostFlow,
+      toHostFlow,
+      bothHostFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > from ip matches ${tnum} (${flowName})`,
+    FilterEntry.parse(`!from:ip=${differentIpsFlow.sourceIp}`)!,
+    false,
+    {
+      differentIpsFlow,
+      sameIpsFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > from ip doesnt matches ${tnum} (${flowName})`,
+    FilterEntry.parse(`!from:ip=${differentIpsFlow.destinationIp}`)!,
+    true,
+    {
+      differentIpsFlow,
+      sameIpsFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) =>
+      `negative > both ip matches ${tnum} (${flowName})`,
+    FilterEntry.parse(`!both:ip=${differentIpsFlow.sourceIp}`)!,
+    false,
+    {
+      differentIpsFlow,
+      sameIpsFlow,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) => {
+      return `negative > both receiver pod matches ${flowName} ${tnum}`;
+    },
+    FilterEntry.parse(`!both:pod=${receiverPod}`)!,
+    false,
+    {
+      fromSenderToReceiverPod,
+      fromReceiverToSenderPod,
+    },
+  );
+
+  testFilterEntry(
+    (flowName: string, tnum: number) => {
+      return `negative > both receiver pod matches ${flowName} ${tnum}`;
+    },
+    FilterEntry.parse(`!both:pod=${receiverPod}`)!,
+    true,
+    {
+      fromSenderToSenderPod,
+    },
+  );
 });

--- a/src/domain/filtering/__tests__/filter-link.test.ts
+++ b/src/domain/filtering/__tests__/filter-link.test.ts
@@ -249,6 +249,36 @@ describe('filterLink', () => {
   );
 
   testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > negative > to match ${n} (${linkName})`,
+    FilterEntry.parse(`!to:identity=dst-456`)!,
+    false,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
+    (linkName: string, n: number) =>
+      `identity > negative > to doesnt match ${n} (${linkName})`,
+    FilterEntry.parse(`!to:identity=dst-456-wrong`)!,
+    true,
+    {
+      tcpForwarded,
+      tcpDropped,
+      tcpUnknown,
+      tcpError,
+      tcpForwardedDropped,
+      tcpMixed,
+    },
+  );
+
+  testFilterEntry(
     (linkName: string, n: number) => `identity > to matches ${n} (${linkName})`,
     FilterEntry.parse(`to:identity=src-123`)!,
     true,

--- a/src/domain/filtering/__tests__/filter-service.test.ts
+++ b/src/domain/filtering/__tests__/filter-service.test.ts
@@ -479,6 +479,27 @@ describe('filterService', () => {
 
   testFilterEntry(
     (svcName: string, tnum: number) =>
+      `identity > negative > both matches ${tnum} (${svcName})`,
+    FilterEntry.parse(`!both:identity=${regular.id}`)!,
+    false,
+    { regular },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
+      `identity > negative > both doesnt match ${tnum} (${svcName})`,
+    FilterEntry.parse(`!both:identity=${regular.id}`)!,
+    true,
+    {
+      world,
+      host,
+      remoteNode,
+      kubeDns,
+    },
+  );
+
+  testFilterEntry(
+    (svcName: string, tnum: number) =>
       `label > to matches ${tnum} (${svcName})`,
     filterEntries.toLabelRegular!,
     true,

--- a/src/domain/filtering/filter-flow.ts
+++ b/src/domain/filtering/filter-flow.ts
@@ -58,14 +58,14 @@ export const filterFlow = (flow: Flow, filters: Filters): boolean => {
     if (rangeSign === '-' && flow.httpStatus > httpStatus) return false;
   }
 
-  let ok = !filters.filters?.length;
-  filters.filters?.forEach((ff: FilterEntry) => {
-    const passed = filterFlowByEntry(flow, ff);
-
-    ok = ok || passed;
-  });
-
-  return ok;
+  const filtered = filters.filters?.some(
+    ff => ff.negative && !filterFlowByEntry(flow, ff),
+  );
+  return filtered
+    ? false
+    : !!filters.filters?.some(
+        ff => !ff.negative && filterFlowByEntry(flow, ff),
+      );
 };
 
 export const filterFlowByEntry = (flow: Flow, filter: FilterEntry): boolean => {
@@ -108,5 +108,5 @@ export const filterFlowByEntry = (flow: Flow, filter: FilterEntry): boolean => {
     }
   }
 
-  return fromOk || toOk;
+  return filter.negative !== (fromOk || toOk);
 };

--- a/src/domain/filtering/filter-link.ts
+++ b/src/domain/filtering/filter-link.ts
@@ -14,14 +14,15 @@ export const filterLink = (link: Link, filters: Filters): boolean => {
 
   if (link.isDNSRequest && filters.skipKubeDns) return false;
 
-  const filtered = filters.filters?.some(
-    ff => ff.negative && !filterLinkByEntry(link, ff),
-  );
-  return filtered
-    ? false
-    : !!filters.filters?.some(
-        ff => !ff.negative && filterLinkByEntry(link, ff),
-      );
+  if (!filters.filters?.length) return true;
+
+  for (const ff of filters.filters) {
+    const ffResult = filterLinkByEntry(link, ff);
+
+    if (ff.negative && !ffResult) return false;
+    if (!ff.negative && ffResult) return true;
+  }
+  return false;
 };
 
 export const filterLinkByEntry = (l: Link, e: FilterEntry): boolean => {

--- a/src/domain/filtering/filter-service.ts
+++ b/src/domain/filtering/filter-service.ts
@@ -17,15 +17,16 @@ export const filterServiceByEntry = (
   service: Service,
   e: FilterEntry,
 ): boolean => {
-  if (e.isIdentity) return service.id === e.query;
+  let pass = true;
+  if (e.isIdentity) pass = service.id === e.query;
 
   if (e.isLabel) {
-    return !!Labels.findKVByString(service.labels, e.query);
+    pass = !!Labels.findKVByString(service.labels, e.query);
   }
 
   if (e.isDNS) {
-    return service.dnsNames.includes(e.query) || service.id === e.query;
+    pass = service.dnsNames.includes(e.query) || service.id === e.query;
   }
 
-  return true;
+  return e.negative !== pass;
 };


### PR DESCRIPTION
FlowsFilterInput could accept negation(!) operator prefixed filters to exclude specified elements.
For example, type `!k8s:io.kubernetes.pod.namespace=ingress` to exclude pods from ingress namespace
This could be a solution for #240.

![2022-12-08_151751](https://user-images.githubusercontent.com/361859/206386915-568156e3-277c-4ffc-adff-804a731c8063.png)
