### PR TITLE
chore: opt out of auto dark theme

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Hubble UI</title>
     <base href="/" />
+    <meta name="color-scheme" content="only light">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"


### PR DESCRIPTION
Browsers can automatically generate dark themes from light themes, but it often looks strange and Hubble is no exception. It's possible to opt out of automatic dark themes by explicitly declaring the theme as light.

https://developer.chrome.com/blog/auto-dark-theme/#using-a-meta-tag

Fixes: #664