### PR TITLE
dependabot: run weekly and use grouped updates for Go and NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
     labels:
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: gomod
     directory: ./backend
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
     ignore:
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
     labels:
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "docker:"
     open-pull-requests-limit: 5
@@ -51,7 +51,7 @@ updates:
   - package-ecosystem: docker
     directory: /backend
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "backend/docker:"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     labels:
     - kind/enhancement
     - release-note/misc
-
+    groups:
+      dev-deps:
+        dependency-type: 'development'
+      prod-deps:
+        dependency-type: 'production'
   - package-ecosystem: gomod
     directory: ./backend
     schedule:
@@ -19,13 +23,17 @@ updates:
     ignore:
       - dependency-name: "github.com/cilium/cilium"
       - dependency-name: "github.com/cilium/hubble"
-        # k8s dependencies will be updated manually all at once
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
     labels:
     - kind/enhancement
     - release-note/misc
-
+    groups:
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      all-go-deps:
+        patterns:
+          - '*'
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -35,7 +43,10 @@ updates:
     labels:
     - kind/enhancement
     - release-note/misc
-
+    groups:
+      all-github-actions:
+        patterns:
+          - '*'
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -47,7 +58,6 @@ updates:
     labels:
     - ci/dependabot
     - kind/enhancement
-
   - package-ecosystem: docker
     directory: /backend
     schedule:


### PR DESCRIPTION
Let's try to reduce the number of dependabot PRs and merge them in a more timely manner.