### PR TITLE
Rename Source and Destination `Service` to `Identity`

### DIFF
--- a/src/components/FlowsTable/Cell.tsx
+++ b/src/components/FlowsTable/Cell.tsx
@@ -32,7 +32,7 @@ export const Cell = memo<CellProps>(function FlowsTableCell(props) {
     case Column.SrcIp: {
       return <div className={css.cell}>{props.flow.sourceIp}</div>;
     }
-    case Column.SrcService: {
+    case Column.SrcIdentity: {
       const appName = props.flow.sourceIdentityName ?? 'No app name';
       const subtitle = props.flow.sourceNamespace ? (
         <span className={css.subtitle}>{props.flow.sourceNamespace}</span>
@@ -55,7 +55,7 @@ export const Cell = memo<CellProps>(function FlowsTableCell(props) {
     case Column.DstIp: {
       return <div className={css.cell}>{props.flow.destinationIp}</div>;
     }
-    case Column.DstService: {
+    case Column.DstIdentity: {
       const appName = props.flow.destinationDns
         ? props.flow.destinationDns
         : props.flow.destinationIdentityName ?? '—';

--- a/src/components/FlowsTable/Header.tsx
+++ b/src/components/FlowsTable/Header.tsx
@@ -14,8 +14,8 @@ export const Header = memo<CommonProps>(function FlowsTableHeader(props) {
       {props.visibleColumns.has(Column.SrcIp) && (
         <div className={css.cell}>{getColumnLabel(Column.SrcIp)}</div>
       )}
-      {props.visibleColumns.has(Column.SrcService) && (
-        <div className={css.cell}>{getColumnLabel(Column.SrcService)}</div>
+      {props.visibleColumns.has(Column.SrcIdentity) && (
+        <div className={css.cell}>{getColumnLabel(Column.SrcIdentity)}</div>
       )}
       {props.visibleColumns.has(Column.DstPod) && (
         <div className={css.cell}>{getColumnLabel(Column.DstPod)}</div>
@@ -23,8 +23,8 @@ export const Header = memo<CommonProps>(function FlowsTableHeader(props) {
       {props.visibleColumns.has(Column.DstIp) && (
         <div className={css.cell}>{getColumnLabel(Column.DstIp)}</div>
       )}
-      {props.visibleColumns.has(Column.DstService) && (
-        <div className={css.cell}>{getColumnLabel(Column.DstService)}</div>
+      {props.visibleColumns.has(Column.DstIdentity) && (
+        <div className={css.cell}>{getColumnLabel(Column.DstIdentity)}</div>
       )}
       {props.visibleColumns.has(Column.DstPort) && (
         <div className={classnames(css.cell, css.dstPort)}>

--- a/src/components/FlowsTable/Row.tsx
+++ b/src/components/FlowsTable/Row.tsx
@@ -59,8 +59,8 @@ export const Row = memo<RowProps>(function FlowsTableRow(props) {
       {props.visibleColumns.has(Column.SrcIp) && (
         <Cell flow={props.flow} kind={Column.SrcIp} />
       )}
-      {props.visibleColumns.has(Column.SrcService) && (
-        <Cell flow={props.flow} kind={Column.SrcService} />
+      {props.visibleColumns.has(Column.SrcIdentity) && (
+        <Cell flow={props.flow} kind={Column.SrcIdentity} />
       )}
       {props.visibleColumns.has(Column.DstPod) && (
         <Cell flow={props.flow} kind={Column.DstPod} />
@@ -68,8 +68,8 @@ export const Row = memo<RowProps>(function FlowsTableRow(props) {
       {props.visibleColumns.has(Column.DstIp) && (
         <Cell flow={props.flow} kind={Column.DstIp} />
       )}
-      {props.visibleColumns.has(Column.DstService) && (
-        <Cell flow={props.flow} kind={Column.DstService} />
+      {props.visibleColumns.has(Column.DstIdentity) && (
+        <Cell flow={props.flow} kind={Column.DstIdentity} />
       )}
       {props.visibleColumns.has(Column.DstPort) && (
         <Cell flow={props.flow} kind={Column.DstPort} />

--- a/src/components/FlowsTable/general.ts
+++ b/src/components/FlowsTable/general.ts
@@ -6,10 +6,10 @@ export enum Column {
   Auth = 'Authentication',
   SrcPod = 'Source Pod',
   SrcIp = 'Source IP',
-  SrcService = 'Source Service',
+  SrcIdentity = 'Source Identity',
   DstPod = 'Destination Pod',
   DstIp = 'Destination IP',
-  DstService = 'Destination Service',
+  DstIdentity = 'Destination Identity',
   DstPort = 'Destination Port',
   L7Info = 'L7 info',
   Verdict = 'Verdict',
@@ -34,8 +34,8 @@ export const getColumnKey = (col: Column): ColumnKey => {
 };
 
 export const defaultVisibleColumns = new Set<Column>([
-  Column.SrcService,
-  Column.DstService,
+  Column.SrcIdentity,
+  Column.DstIdentity,
   Column.DstPort,
   Column.L7Info,
   Column.Verdict,

--- a/src/storage/local/__tests__/store-restore.test.ts
+++ b/src/storage/local/__tests__/store-restore.test.ts
@@ -20,14 +20,14 @@ describe('consistency tests for setItem / getItem', () => {
     const getItem = jest.spyOn(Storage.prototype, 'getItem');
     const setItem = jest.spyOn(Storage.prototype, 'setItem');
 
-    const arr = [Column.SrcService];
+    const arr = [Column.SrcIdentity];
     saveFlowsTableVisibleColumns(new Set(arr));
 
     expect(setItem.mock.calls.length).toBe(1);
     expect(setItem.mock.calls[0][1]).toBe(JSON.stringify(arr));
 
     const data = getFlowsTableVisibleColumns();
-    expect(data).toEqual(new Set([Column.SrcService]));
+    expect(data).toEqual(new Set([Column.SrcIdentity]));
   });
 
   test('flows table visible columns 3', () => {


### PR DESCRIPTION
The `Source Service` and `Destination Service` columns have slightly confusing names as they appear to be security identities rather than service identities, a non-existent concept.

This renames references of `Source Service` to `Source Identity` and `Destination Service` to `Destination Identity`.

Fixes: #249