### PR TITLE
Update `Dockerfile` to use `NODE_ENV=development`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY patches/ patches/
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
-RUN npm --target_arch=${TARGETARCH} install
+RUN NODE_ENV=development npm --target_arch=${TARGETARCH} install
 
 COPY . .
 


### PR DESCRIPTION
Previously, the `build-and-push-prs` jobs would fail with the error: 
```
ERROR: failed to solve: process "/bin/sh -c npm --target_arch=${TARGETARCH} install" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c npm --target_arch=${TARGETARCH} install" did not complete successfully: exit code: 1
```

This resolves the issue by altering the `Dockerfile` and setting the Node environment to a **development** environment when running `npm install` against the target architecture. We achieve this by adding to `NODE_ENV=development` to `RUN npm --target_arch=${TARGETARCH} install`. 

The result? 🪄 

```dockerfile
RUN NODE_ENV=development npm --target_arch=${TARGETARCH} install
```