### PR TITLE
Welcome screen: Allow scroll when namespaces list overflow

### DIFF
--- a/src/components/ServiceMapApp/WelcomeScreen.scss
+++ b/src/components/ServiceMapApp/WelcomeScreen.scss
@@ -3,7 +3,7 @@
 .wrapper {
   flex-grow: 1;
   width: 100%;
-  height: 100%;
+  overflow: auto;
 }
 
 .content {

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,8 +3,8 @@
 :global {
   html {
     box-sizing: border-box;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
-      sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     height: 100%;
   }
 
@@ -23,6 +23,7 @@
     min-height: 100%;
     background-color: #fff;
     font-size: 16px;
+    overscroll-behavior: none;
   }
 
   .light {


### PR DESCRIPTION
Issue https://github.com/cilium/hubble-ui/issues/776.

### Summary

This PR allows page scroll on the welcome screen so users can see the full list of their namespaces when it overflows. Additionally, this PR removes the ability to "over scroll".

### Changes

- Allow overflow on the welcome screen
- Add `overscroll-behavior: none;` on the body
- Some scss lint changes

### Screenshot

| Before | After |
|---|---|
|![2024-02-08 11 33 09](https://github.com/cilium/hubble-ui/assets/1910449/4a3c5402-ac95-42fa-a015-5a6f4070487c)|![2024-02-08 11 32 44](https://github.com/cilium/hubble-ui/assets/1910449/0ab0001a-f2a5-452c-aec6-c6e4cdf643fd)|

### Functional testing

- Open Hubble UI with a lot of namespaces (or with a small screen)
- Observe that you can scroll the welcome screen down and see all your namespaces

### Future work

- Are we enforcing formatting on PRs before merges? There were some formatting changes in parts that this PR isn't touching...
- It looks like the service map page has always some 20px overflow and display a scroll (in Chrome):

<img width="1362" alt="Screenshot 2024-02-08 at 11 51 25" src="https://github.com/cilium/hubble-ui/assets/1910449/1140bff3-a621-4f6a-8407-5625da9a56fa">



