### PR TITLE
Service map page: remove unnecessary scroll

### DIFF
--- a/src/components/ServiceMapArrowRenderer/ServiceMapArrowDuckFeet.tsx
+++ b/src/components/ServiceMapArrowRenderer/ServiceMapArrowDuckFeet.tsx
@@ -116,7 +116,7 @@ export const ServiceMapArrowDuckFeet = observer(function ServiceMapArrowDuckFeet
         .append('div')
         .style('position', 'absolute')
         .style('z-index', '10')
-        .style('visibility', 'hidden')
+        .style('display', 'none')
         .style('color', '#fff')
         .style('background', '#000')
         .style('border-radius', '3px')
@@ -137,14 +137,14 @@ export const ServiceMapArrowDuckFeet = observer(function ServiceMapArrowDuckFeet
         .attr('x', arrow => arrow.end!.x - 8)
         .attr('y', arrow => arrow.end!.y - 20)
         .text((arrow: AccessPointArrow) => (arrow.hasAuth ? '\uf232' : ''))
-        .on('mouseover', () => padlockTooltip.style('visibility', 'visible'))
+        .on('mouseover', () => padlockTooltip.style('display', 'block'))
         .on('mousemove', evt => {
           return padlockTooltip
             .style('top', evt.pageY - 10 + 'px')
             .style('left', evt.pageX + 10 + 'px');
         })
         .on('mouseout', () => {
-          return padlockTooltip.style('visibility', 'hidden');
+          return padlockTooltip.style('display', 'none');
         });
 
       backgroundLines.exit().remove();


### PR DESCRIPTION
No issue.

### Summary

No matter what, the service map page were showing a scroll on Chrome. This PR removes it.

### Changes

- Remove hidden elements from DOM's tree using `display: none` instead of `visibilitiy: hidden`

### Screenshots

| Before | After |
|---|---|
|<img width="1362" alt="Screenshot 2024-02-08 at 11 51 25" src="https://github.com/cilium/hubble-ui/assets/1910449/1f468e29-5d01-4219-924e-bdac250e882f">|<img width="1196" alt="Screenshot 2024-02-08 at 16 42 02" src="https://github.com/cilium/hubble-ui/assets/1910449/72cb194f-1347-4807-afac-1ce98a57f79e">|

### Functional testing

- Open Hubble UI and select a namespace
- Observe that the page does not have a scroll bar anymore on the entire body
- **!!!important!!!** Verify that if you move your mouse over the "lock" icons, the tooltup is still displayed:
<img width="300" alt="Screenshot 2024-02-08 at 16 40 40" src="https://github.com/cilium/hubble-ui/assets/1910449/dade8278-5dc3-45bd-b2f0-ea93ba025d1a">

_I could not test the last part because I am not sure when those icons show up. using the default demo app, it is not showing up_