### PR TITLE
Remove wrong key lookup for service name in k8s labels

### DIFF
--- a/src/domain/__tests__/labels.ts
+++ b/src/domain/__tests__/labels.ts
@@ -66,9 +66,4 @@ describe('extract app name', () => {
 
     appNameTest(['k8s:app.kubernetes.io/name=EXPECTED_NAME'], 'EXPECTED_NAME');
   });
-
-  test('random label without explicit appName', () => {
-    appNameTest(['k8s:random-app=random-name'], 'random-name');
-    appNameTest(['k8s:random-name=random-app'], 'random-app');
-  });
 });

--- a/src/domain/labels.ts
+++ b/src/domain/labels.ts
@@ -54,7 +54,6 @@ export class Labels {
   ];
 
   public static readonly appNameNormalizedKeys = new Set([
-    'component',
     'app',
     'name',
     'functionname',


### PR DESCRIPTION
Issue https://github.com/cilium/hubble-ui/issues/792.

### Description

This PR fixes a bug introduced in https://github.com/isovalent/hubble-ui-enterprise/pull/1108: the key `component` was wrongly added to the list of keys to retrieve an app app name from k8s labels.

### Changes

- Removed `component`

### Screenshots

|Before|After|
|---|---|
|<img width="1215" alt="Screenshot 2024-03-18 at 22 00 57" src="https://github.com/isovalent/hubble-ui-enterprise/assets/1910449/a88b56df-8557-4e95-ac9e-5dc331f87c07">|<img width="799" alt="Screenshot 2024-03-18 at 22 01 17" src="https://github.com/isovalent/hubble-ui-enterprise/assets/1910449/27459576-0bea-48b2-8b6e-398c901e8a01">|

### Unit tests

None added.

### Functional tests

- In a cluster, add a label such as `component` is suffixing it:
   - `kubectl label pods crawler-7748bbc7b8-xr2vn app.kubernetes.io/component=api -n tenant-jobs`
- Open Hubble UI and go to the service map
- Observe that the service card has the correct name and not the name you added with the `component` label
