### PR TITLE
Migrate blueprint MultiSelect2

### DIFF
--- a/src/components/TopBar/FlowsFilterInput.tsx
+++ b/src/components/TopBar/FlowsFilterInput.tsx
@@ -1,5 +1,5 @@
 import { Button, Classes, MenuItem } from '@blueprintjs/core';
-import { ItemRenderer, MultiSelect2 } from '@blueprintjs/select';
+import { ItemRenderer, MultiSelect } from '@blueprintjs/select';
 import { trim } from 'lodash';
 import React, { useCallback, useState } from 'react';
 
@@ -14,8 +14,6 @@ interface Props {
   filters: FilterEntry[];
   onChange?: (filters: FilterEntry[]) => void;
 }
-
-const FilterMultiSelect = MultiSelect2.ofType<FilterEntry | null>();
 
 export const FlowsFilterInput = (props: Props) => {
   const [userInput, setUserInput] = useState<string>('');
@@ -70,7 +68,7 @@ export const FlowsFilterInput = (props: Props) => {
   ) : undefined;
 
   return (
-    <FilterMultiSelect
+    <MultiSelect
       initialContent={null}
       className={css.container}
       query={userInput}


### PR DESCRIPTION
### Summary

Migrate the deprecated MultiSelect2 to MultiSelect.

### Changes

- Change MultiSelect2 to MultiSelect

### Screenshots
![Screenshot 2024-04-18 at 10 37 09](https://github.com/cilium/hubble-ui/assets/1910449/2c1dd315-d7ac-4a07-9279-23989cc53053)
![Screenshot 2024-04-18 at 10 36 38](https://github.com/cilium/hubble-ui/assets/1910449/1dd4a724-eff6-4a5b-b598-7ab2ce70f9bd)

### Unit tests

n/a

### Functional tests

- Open Hubble UI and select a namespace
- Observe that the filter input looks good in the top bar
- Click on a service card
- Check that the labels are still well rendered in the top bar
