### PR TITLE
backend/internal/config: log env var fallback as info instead of warning

### DIFF
--- a/backend/internal/config/prop_getters.go
+++ b/backend/internal/config/prop_getters.go
@@ -181,5 +181,5 @@ func (er *EnvVarResult[T]) LogIfFallback(log logrus.FieldLogger) {
 	log.
 		WithField("var", er.VarName).
 		WithField("fallback", fmt.Sprintf("%v", er.Value)).
-		Warn("using fallback value for env var")
+		Info("using fallback value for env var")
 }


### PR DESCRIPTION
The cilium-cli connectivity test treats warnings in the logs as test errors[^1]. This causes tests involving hubble-ui to fail[^2]. As these fallbacks aren't really warnings but rather
informative messsages, demote them to info level.

[^1]: https://github.com/cilium/cilium/pull/35723
[^2]: https://github.com/cilium/cilium-cli/actions/runs/12051244564/job/33601849065?pr=2869#step:13:541