### PR TITLE
fix: 404 Not Found error when baseUrl is not /

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,14 @@ declare global {
 
 const buildAPIUrl = (env: Environment): string => {
   if (!env.isDev) {
-    return `${document.location.origin}/api/`;
+    const fallbackAPIUrl = `${document.location.origin}/api/`;
+    try {
+      const base = document.querySelector('base')?.href;
+      if (base != null) return new URL('api/', base).href;
+    } catch (e) {
+      console.error('Failed to determine API path', e);
+    }
+    return fallbackAPIUrl;
   }
 
   // NOTE: Do not edit those `process.env.VAR_NAME` variable accesses

--- a/src/router/Routes.tsx
+++ b/src/router/Routes.tsx
@@ -10,21 +10,39 @@ export type Props = {
   RootComponent: JSX.Element;
 };
 
+const pathname = (href: string | undefined) => {
+  if (href == null) return undefined;
+  try {
+    return new URL(href).pathname;
+  } catch (e) {
+    console.error('Failed to determine base path', e);
+    return undefined;
+  }
+};
+
 export const Routes = function Routes(props: Props) {
   const createRouter = props.router.isInMemory ? createMemoryRouter : createBrowserRouter;
+  const opts = props.router.isInMemory
+    ? undefined
+    : {
+        basename: pathname(document.querySelector('base')?.href),
+      };
 
-  const router = createRouter([
-    {
-      path: '/',
-      element: props.RootComponent,
-      children: [
-        {
-          path: ApplicationPath.ServiceMap,
-          element: <ServiceMapApp />,
-        },
-      ],
-    },
-  ]);
+  const router = createRouter(
+    [
+      {
+        path: '/',
+        element: props.RootComponent,
+        children: [
+          {
+            path: ApplicationPath.ServiceMap,
+            element: <ServiceMapApp />,
+          },
+        ],
+      },
+    ],
+    opts,
+  );
 
   return <RouterProvider router={router} />;
 };


### PR DESCRIPTION
Fix #854
Fix #889

This pull request fixes a bug which hubble-ui will not work if `hubble.ui.baseUrl` is specified to other than `/`.

after this pull-request, hubble-ui now correctly consider `<base href>` tag (if available) for:
* API path (previously hardcoded to `${location.origin}/api/`)
* react-router's base path (previously not specified, which causes default value: `/`)

side note: `<base href>` is changed by cillium's nginx, see https://github.com/cilium/cilium/blob/5a4fdc967a51146c15b65e5401ecb5d7decdd8d2/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl#L31

