### PR TITLE
Support world connection with ipv6

### DIFF
--- a/src/domain/filtering/__tests__/filter-service.test.ts
+++ b/src/domain/filtering/__tests__/filter-service.test.ts
@@ -48,6 +48,7 @@ const testFilterEntry = (
 describe('filterService', () => {
   const regular = ServiceCard.fromService(services.regular);
   const world = ServiceCard.fromService(services.world);
+  const worldIPv6 = ServiceCard.fromService(services.worldIPv6);
   const host = ServiceCard.fromService(services.host);
   const remoteNode = ServiceCard.fromService(services.remoteNode);
   const kubeDns = ServiceCard.fromService(services.kubeDNS);
@@ -61,10 +62,18 @@ describe('filterService', () => {
     expect(regular.workload).toBeTruthy();
 
     expect(world.isWorld).toBe(true);
+    expect(world.isWorldIPv6).toBe(false);
     expect(world.isHost).toBe(false);
     expect(world.isKubeDNS).toBe(false);
     expect(world.isPrometheusApp).toBe(false);
     expect(world.isRemoteNode).toBe(false);
+
+    expect(worldIPv6.isWorld).toBe(true);
+    expect(worldIPv6.isWorldIPv6).toBe(true);
+    expect(worldIPv6.isHost).toBe(false);
+    expect(worldIPv6.isKubeDNS).toBe(false);
+    expect(worldIPv6.isPrometheusApp).toBe(false);
+    expect(worldIPv6.isRemoteNode).toBe(false);
 
     expect(host.isWorld).toBe(false);
     expect(host.isHost).toBe(true);

--- a/src/domain/labels.ts
+++ b/src/domain/labels.ts
@@ -22,6 +22,7 @@ export enum ReservedLabel {
   Host = 'reserved:host',
   KubeApiserver = 'reserved:kube-apiserver',
   World = 'reserved:world',
+  WorldIPv6 = 'reserved:world-ipv6',
   Health = 'reserved:health',
   Init = 'reserved:init',
   Ingress = 'reserved:ingress',
@@ -130,6 +131,17 @@ export class Labels {
 
       const hasNamespace = Labels.containsKey(kv, ['namespace']);
       if (hasNamespace) return kv.value;
+    }
+
+    return null;
+  }
+
+  public static findWorldInLabels(labels: KV[], normalizeLabels = true): string | null {
+    for (const lbl of labels) {
+      const kv = normalizeLabels ? Labels.normalizeLabel(lbl) : lbl;
+      if (kv.key === ReservedLabel.World || kv.key === ReservedLabel.WorldIPv6) {
+        return kv.key;
+      }
     }
 
     return null;
@@ -314,10 +326,6 @@ export class Labels {
     return Labels.specialLabelKeys.has(key);
   }
 
-  public static isWorld(labels: KV[]): boolean {
-    return Labels.haveReserved(labels, ReservedLabel.World);
-  }
-
   public static isHost(labels: KV[]): boolean {
     return Labels.haveReserved(labels, ReservedLabel.Host);
   }
@@ -360,7 +368,10 @@ export class Labels {
     labels.forEach((lbl: KV) => {
       const kv = Labels.normalizeLabel(lbl);
 
-      props.isWorld = !!props.isWorld || Labels.isReserved(kv, ReservedLabel.World, false);
+      props.isWorld =
+        !!props.isWorld ||
+        Labels.isReserved(kv, ReservedLabel.World, false) ||
+        Labels.isReserved(kv, ReservedLabel.WorldIPv6, false);
       props.isKubeApiserver =
         !!props.isKubeApiserver || Labels.isReserved(kv, ReservedLabel.KubeApiserver, false);
       props.isHost = !!props.isHost || Labels.isReserved(kv, ReservedLabel.Host, false);

--- a/src/domain/service-map/card.ts
+++ b/src/domain/service-map/card.ts
@@ -142,8 +142,8 @@ export class ServiceCard extends AbstractCard {
       result.push(FilterEntry.newLabel(ReservedLabel.Ingress));
     }
 
-    if (this.isWorld) {
-      result.push(FilterEntry.newLabel(ReservedLabel.World));
+    if (this.isWorld && this.worldLabel) {
+      result.push(FilterEntry.newLabel(this.worldLabel));
     }
 
     if (this.isKubeDNS) {
@@ -269,8 +269,17 @@ export class ServiceCard extends AbstractCard {
     return this.service.namespace || Labels.findNamespaceInLabels(this.labels);
   }
 
+  @computed
+  public get worldLabel(): string | null {
+    return Labels.findWorldInLabels(this.labels);
+  }
+
   public get isWorld(): boolean {
     return this.labelsProps.isWorld;
+  }
+
+  public get isWorldIPv6(): boolean {
+    return this.labelsProps.isWorld && this.worldLabel === ReservedLabel.WorldIPv6;
   }
 
   public get isHost(): boolean {

--- a/src/testing/data/services.ts
+++ b/src/testing/data/services.ts
@@ -126,3 +126,14 @@ export const sameNamespace = {
     labels: replaceNsLabel(kubeDNS.labels),
   },
 };
+
+export const worldIPv6: HubbleService = {
+  id: 'world-ipv6-service',
+  name: 'world-ipv6-service',
+  namespace: 'world-ipv6-service-ns',
+  labels: [Labels.toKV(ReservedLabel.WorldIPv6)],
+  dnsNames: [],
+  workloads: [],
+  identity: MockServiceIdentity.World,
+  ...restOfService,
+};


### PR DESCRIPTION
### Summary

This PR adds support for incoming connections with ipv6 to be displayed as world instead of unkonwn

### Changes

- Added corresponding labels
- Test for both work in ipv4 and ipv6

### Screenshots

Not yet, i need to find an ipv6 cluster to test this

### Unit tests

Added

### Functional test

- Open Hubble UI in a cluster with ipv6 traffic
- Check that the world is displayed, and that there is no Unknown app anymore