### PR TITLE
feat: add export button for service map connections

### DIFF
--- a/src/components/ServiceMapApp/index.tsx
+++ b/src/components/ServiceMapApp/index.tsx
@@ -21,6 +21,7 @@ import { KV, Labels } from '~/domain/labels';
 import { FilterEntry, FilterDirection } from '~/domain/filtering';
 
 import { useApplication } from '~/application';
+import { ServiceMapExporter } from '~/utils/export';
 
 import { sizes } from '~/ui/vars';
 import { useFlowsTableColumns } from './hooks/useColumns';
@@ -119,6 +120,12 @@ export const ServiceMapApp = observer(function ServiceMapApp() {
     ui.controls.setFlowFilters([FilterEntry.newDNS(dns).setDirection(FilterDirection.Either)]);
   }, []);
 
+  const onExport = useCallback(() => {
+    const services = store.currentFrame.services.cardsMap;
+    const links = store.currentFrame.interactions.links;
+    ServiceMapExporter.export(services, links);
+  }, [store.currentFrame]);
+
   const cardRenderer = mobx.action((props: CardProps<ServiceCard>) => {
     const l7endpoints = store.currentFrame.interactions.l7endpoints;
 
@@ -166,6 +173,7 @@ export const ServiceMapApp = observer(function ServiceMapApp() {
       onShowRemoteNodeToggle={() => ui.controls.toggleShowRemoteNode()}
       showPrometheusApp={store.controls.showPrometheusApp}
       onShowPrometheusAppToggle={() => ui.controls.toggleShowPrometheusApp()}
+      onExport={onExport}
     />
   );
 

--- a/src/components/TopBar/ExportButton.tsx
+++ b/src/components/TopBar/ExportButton.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback } from 'react';
+import { observer } from 'mobx-react';
+
+import { Icon, Button } from '@blueprintjs/core';
+
+import css from './styles.scss';
+
+export interface Props {
+  onExport?: () => void;
+}
+
+export const ExportButton = observer(function ExportButton(props: Props) {
+  const handleClick = useCallback(() => {
+    props.onExport?.();
+  }, [props.onExport]);
+
+  return (
+    <Button
+      minimal
+      small
+      icon={<Icon icon="export" iconSize={16} />}
+      onClick={handleClick}
+      title="Export Service Map Connections"
+    >
+      Export
+    </Button>
+  );
+});

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -12,6 +12,7 @@ import { VerdictFilterDropdown } from './VerdictFilterDropdown';
 import { VisualFiltersDropdown } from './VisualFiltersDropdown';
 import { NamespaceSelectorDropdown } from './NamespaceSelectorDropdown';
 import { ConnectionIndicator } from './ConnectionIndicator';
+import { ExportButton } from './ExportButton';
 
 import css from './styles.scss';
 
@@ -35,6 +36,7 @@ export interface Props {
   onShowRemoteNodeToggle?: () => void;
   showPrometheusApp: boolean;
   onShowPrometheusAppToggle: () => void;
+  onExport?: () => void;
 }
 
 export const TopBar = observer(function TopBar(props: Props) {
@@ -72,6 +74,7 @@ export const TopBar = observer(function TopBar(props: Props) {
         {props.currentNamespace && RenderedFilters}
       </div>
       <div className={css.right}>
+        <ExportButton onExport={props.onExport} />
         <div className={css.spacer} />
         <div className={css.spacer} />
 

--- a/src/utils/export/index.ts
+++ b/src/utils/export/index.ts
@@ -1,0 +1,2 @@
+export { ServiceMapExporter } from './serviceMapExporter';
+export type { ExportedConnection, ExportedServiceMap } from './types';

--- a/src/utils/export/serviceMapExporter.ts
+++ b/src/utils/export/serviceMapExporter.ts
@@ -1,0 +1,133 @@
+import { ServiceCard } from '~/domain/service-map/card';
+import { Link } from '~/domain/link';
+import { ExportedConnection, ExportedServiceMap } from './types';
+
+export class ServiceMapExporter {
+  /**
+   * Exports service map connections to JSON format
+   */
+  public static exportToJSON(
+    services: Map<string, ServiceCard>,
+    links: Link[],
+  ): ExportedServiceMap {
+    const connections: ExportedConnection[] = [];
+    let skippedLinks = 0;
+
+    console.log('[ServiceMapExporter] Starting export...', {
+      totalServices: services.size,
+      totalLinks: links.length,
+    });
+
+    for (const link of links) {
+      const sourceService = services.get(link.sourceId);
+      const destService = services.get(link.destinationId);
+
+      // Skip if we can't find either service
+      if (!sourceService || !destService) {
+        skippedLinks++;
+        console.warn('[ServiceMapExporter] Skipping link - service not found:', {
+          sourceId: link.sourceId,
+          destId: link.destinationId,
+          sourceFound: !!sourceService,
+          destFound: !!destService,
+        });
+        continue;
+      }
+
+      const latency = link.throughput.latency;
+      connections.push({
+        source: {
+          id: link.sourceId,
+          name: sourceService.caption,
+          namespace: sourceService.namespace,
+        },
+        destination: {
+          id: link.destinationId,
+          name: destService.caption,
+          namespace: destService.namespace,
+        },
+        destinationPort: link.destinationPort,
+        ipProtocol: link.ipProtocol.toString(),
+        verdicts: Array.from(link.verdicts).map(v => v.toString()),
+        authTypes: Array.from(link.authTypes).map(a => a.toString()),
+        isEncrypted: link.isEncrypted,
+        throughput: {
+          flowAmount: link.throughput.flowAmount,
+          latency: latency
+            ? {
+                min: Number(latency.min.seconds),
+                max: Number(latency.max.seconds),
+                avg: Number(latency.avg.seconds),
+              }
+            : null,
+          bytesTransfered: link.throughput.bytesTransfered,
+        },
+      });
+    }
+
+    // Calculate unique services involved in connections
+    const uniqueServiceIds = new Set<string>();
+    connections.forEach(conn => {
+      uniqueServiceIds.add(conn.source.id);
+      uniqueServiceIds.add(conn.destination.id);
+    });
+
+    const result = {
+      exportedAt: new Date().toISOString(),
+      connections,
+      summary: {
+        totalConnections: connections.length,
+        totalServices: uniqueServiceIds.size,
+      },
+    };
+
+    console.log('[ServiceMapExporter] Export complete:', {
+      exportedConnections: result.summary.totalConnections,
+      uniqueServices: result.summary.totalServices,
+      skippedLinks,
+      timestamp: result.exportedAt,
+    });
+
+    // Log sample connections for verification
+    if (connections.length > 0) {
+      console.log('[ServiceMapExporter] Sample connections (first 3):',
+        connections.slice(0, 3).map(c => ({
+          from: `${c.source.name} (${c.source.namespace})`,
+          to: `${c.destination.name} (${c.destination.namespace})`,
+          port: c.destinationPort,
+          protocol: c.ipProtocol,
+          encrypted: c.isEncrypted,
+        }))
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Downloads the exported data as a JSON file
+   */
+  public static downloadJSON(data: ExportedServiceMap, filename?: string): void {
+    const jsonString = JSON.stringify(data, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename || `hubble-service-map-${Date.now()}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Clean up the URL object
+    URL.revokeObjectURL(url);
+  }
+
+  /**
+   * Exports and downloads service map connections in one operation
+   */
+  public static export(services: Map<string, ServiceCard>, links: Link[]): void {
+    const data = this.exportToJSON(services, links);
+    this.downloadJSON(data);
+  }
+}

--- a/src/utils/export/types.ts
+++ b/src/utils/export/types.ts
@@ -1,0 +1,35 @@
+export interface ExportedConnection {
+  source: {
+    id: string;
+    name: string;
+    namespace: string | null;
+  };
+  destination: {
+    id: string;
+    name: string;
+    namespace: string | null;
+  };
+  destinationPort: number;
+  ipProtocol: string;
+  verdicts: string[];
+  authTypes: string[];
+  isEncrypted: boolean;
+  throughput: {
+    flowAmount: number;
+    latency: {
+      min: number;
+      max: number;
+      avg: number;
+    } | null;
+    bytesTransfered: number;
+  };
+}
+
+export interface ExportedServiceMap {
+  exportedAt: string;
+  connections: ExportedConnection[];
+  summary: {
+    totalConnections: number;
+    totalServices: number;
+  };
+}


### PR DESCRIPTION
 ## Add Export Button for Service Map Connections

  Related issue [#239](https://github.com/cilium/hubble-ui/issues/239)

  ### Overview
  This PR adds an export button to the service map that allows users to download endpoint connections as a JSON file. The export captures the current service map topology without including the underlying flow logs.

  ### Changes
  - **New ExportButton component** (`src/components/TopBar/ExportButton.tsx`)
    - Simple button with export icon positioned in the TopBar
    - Triggers export on click

  - **Export utilities** (`src/utils/export/`)
    - `ServiceMapExporter` class with JSON export functionality
    - Type definitions for exported data structure
    - Console logging for debugging and verification

  - **Integration**
    - Added export handler to ServiceMapApp component
    - Wired export button to TopBar component

  ### Exported Data Format
  The JSON export includes for each connection:
  - **Source/Destination**: Service names, IDs, and namespaces
  - **Network Details**: Destination port and IP protocol
  - **Security**: Verdicts (Allowed, Dropped, Error), authentication types, encryption status
  - **Metrics**: Throughput (flow amount, latency, bytes transferred)
  - **Summary**: Total connections and unique services count

##  Testing

Tested with a local kind cluster running Cilium/Hubble:
  - Export button appears in the TopBar
  - Downloads JSON file with accurate connection data
  - Console logs verify export process
 
<details><summary><h3>Example Export</h3></summary> 

Extracted from tests

  ```json
 {
  "exportedAt": "2025-12-03T16:15:23.768Z",
  "connections": [
    {
      "source": {
        "id": "4231",
        "name": "client",
        "namespace": "app-a"
      },
      "destination": {
        "id": "43557",
        "name": "kube-dns",
        "namespace": "kube-system"
      },
      "destinationPort": 53,
      "ipProtocol": "2",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "5853",
        "name": "client",
        "namespace": "app-b"
      },
      "destination": {
        "id": "43557",
        "name": "kube-dns",
        "namespace": "kube-system"
      },
      "destinationPort": 53,
      "ipProtocol": "2",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "1",
        "name": "host",
        "namespace": null
      },
      "destination": {
        "id": "43557",
        "name": "kube-dns",
        "namespace": "kube-system"
      },
      "destinationPort": 8080,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "1",
        "name": "host",
        "namespace": null
      },
      "destination": {
        "id": "43557",
        "name": "kube-dns",
        "namespace": "kube-system"
      },
      "destinationPort": 8181,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "14998",
        "name": "hubble-relay",
        "namespace": "kube-system"
      },
      "destination": {
        "id": "1",
        "name": "host",
        "namespace": null
      },
      "destinationPort": 4244,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "1",
        "name": "host",
        "namespace": null
      },
      "destination": {
        "id": "14998",
        "name": "hubble-relay",
        "namespace": "kube-system"
      },
      "destinationPort": 4222,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "1",
        "name": "host",
        "namespace": null
      },
      "destination": {
        "id": "3615",
        "name": "hubble-ui",
        "namespace": "kube-system"
      },
      "destinationPort": 8081,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "3615",
        "name": "hubble-ui",
        "namespace": "kube-system"
      },
      "destination": {
        "id": "43557",
        "name": "kube-dns",
        "namespace": "kube-system"
      },
      "destinationPort": 53,
      "ipProtocol": "2",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "3615",
        "name": "hubble-ui",
        "namespace": "kube-system"
      },
      "destination": {
        "id": "14998",
        "name": "hubble-relay",
        "namespace": "kube-system"
      },
      "destinationPort": 4245,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    },
    {
      "source": {
        "id": "43557",
        "name": "kube-dns",
        "namespace": "kube-system"
      },
      "destination": {
        "id": "1",
        "name": "host",
        "namespace": null
      },
      "destinationPort": 6443,
      "ipProtocol": "1",
      "verdicts": [
        "1"
      ],
      "authTypes": [
        "0"
      ],
      "isEncrypted": false,
      "throughput": {
        "flowAmount": 0,
        "latency": {
          "min": 0,
          "max": 0,
          "avg": 0
        },
        "bytesTransfered": 0
      }
    }
  ],
  "summary": {
    "totalConnections": 10,
    "totalServices": 6
  }
}
```

</details>

<details><summary><h3>UI changes</h3></summary>
<img width="1787" height="793" alt="export" src="https://github.com/user-attachments/assets/e5837ca4-e927-42ed-808c-7496a554e630" />
</details>