### PR TITLE
Added 'release' stage names to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ARG NODE_ENV=production
 RUN npm run build
 
 # skopeo inspect --override-os linux --override-arch amd64 docker://docker.io/nginxinc/nginx-unprivileged:1.29.0-alpine3.22-slim | jq -r '.Digest'
-FROM docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine3.22-slim@sha256:76f79f1f3c906a43076086e4517b019b3ab5cc18b3ed1b13417b583e0ab9b298
+FROM docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine3.22-slim@sha256:76f79f1f3c906a43076086e4517b019b3ab5cc18b3ed1b13417b583e0ab9b298 AS release
 USER root
 RUN apk upgrade --no-cache
 USER 101

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -ldflags "-s -w" -o backend
 
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Required by images-release GHA workflow which names them as build targets.

Should fix the image build issue in https://github.com/cilium/hubble-ui/actions/runs/21677399628/job/62501604141