### PR TITLE
http-client: fix 'occured' -> 'occurred' in error message

### DIFF
--- a/src/api/http-client/result.ts
+++ b/src/api/http-client/result.ts
@@ -33,7 +33,7 @@ export class HTTPResult<T = Blob> {
   }
 
   public get errorMessage(): string {
-    return this.isConnectionError ? 'Network error occured' : this.response.statusText;
+    return this.isConnectionError ? 'Network error occurred' : this.response.statusText;
   }
 
   public get headers(): Response['headers'] {


### PR DESCRIPTION
Error message in `src/api/http-client/result.ts` line 36 reads `Network error occured`. User-visible. Fixed to `occurred`. String-literal-only change.