### PR TITLE
chore: typo `occured` -> `occurred` in status-center

### DIFF
--- a/src/ui-layer/status-center.ts
+++ b/src/ui-layer/status-center.ts
@@ -194,7 +194,7 @@ export class StatusCenter extends EventEmitter<Handlers> {
   public pushControlStreamError(err: CustomError) {
     const entry = StatusEntryBuilder.new()
       .setIntent(Intent.Critical)
-      .setTitle('Server error occured')
+      .setTitle('Server error occurred')
       .setComponent(Component.HubbleUI)
       .setDetails(err.toString())
       .build();
@@ -435,7 +435,7 @@ export class StatusCenter extends EventEmitter<Handlers> {
 
     return builder
       .setIntent(intent)
-      .setTitle(builder.statusEntry.title || err.metadata['title']?.[0] || 'GRPC error occured')
+      .setTitle(builder.statusEntry.title || err.metadata['title']?.[0] || 'GRPC error occurred')
       .setDetails(builder.statusEntry.details || this.formatErrorDetails(err))
       .setComponent(err.metadata['component']?.[0] || Component.HubbleUI)
       .setUnderlyingError(err);

--- a/src/ui/status-center/index.ts
+++ b/src/ui/status-center/index.ts
@@ -118,7 +118,7 @@ export class StatusEntry {
     return this.intent === Intent.Debug;
   }
 
-  // NOTE: Call this method when the same event occured multiple times
+  // NOTE: Call this method when the same event occurred multiple times
   public occuredAgain(entry: StatusEntry) {
     this.title = entry.title;
     this.intent = entry.intent;


### PR DESCRIPTION
Three single-character typo fixes — two user-visible status-center titles and one comment:

- `src/ui-layer/status-center.ts:197` — `setTitle("Server error occured")` -> `setTitle("Server error occurred")`
- `src/ui-layer/status-center.ts:438` — `"GRPC error occured"` -> `"GRPC error occurred"`
- `src/ui/status-center/index.ts:121` — comment `the same event occured multiple times` -> `the same event occurred multiple times`