### PR TITLE
fix: delay debounce until the first event

### DIFF
--- a/backend/pkg/debounce/debounce.go
+++ b/backend/pkg/debounce/debounce.go
@@ -17,9 +17,7 @@ func New(delay time.Duration) *Debounce {
 }
 
 func (d *Debounce) Touch() {
-	if d.ensureTicker() {
-		return
-	}
+	d.ensureTicker()
 
 	if !d.ticker.Stop() {
 		select {
@@ -47,6 +45,13 @@ func (d *Debounce) Stop() {
 func (d *Debounce) ensureTicker() bool {
 	if d.ticker == nil {
 		d.ticker = time.NewTimer(d.delay)
+		if !d.ticker.Stop() {
+			select {
+			case <-d.ticker.C:
+			default:
+			}
+		}
+
 		return true
 	}
 

--- a/backend/pkg/debounce/debounce_test.go
+++ b/backend/pkg/debounce/debounce_test.go
@@ -1,0 +1,56 @@
+package debounce
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTriggeredDoesNotFireBeforeTouch(t *testing.T) {
+	t.Parallel()
+
+	d := New(20 * time.Millisecond)
+
+	select {
+	case <-d.Triggered():
+		t.Fatal("debounce triggered before Touch")
+	case <-time.After(60 * time.Millisecond):
+	}
+}
+
+func TestTouchTriggersAfterDelay(t *testing.T) {
+	t.Parallel()
+
+	d := New(20 * time.Millisecond)
+	start := time.Now()
+	d.Touch()
+
+	select {
+	case <-d.Triggered():
+		if elapsed := time.Since(start); elapsed < 15*time.Millisecond {
+			t.Fatalf("debounce triggered too early: %s", elapsed)
+		}
+	case <-time.After(80 * time.Millisecond):
+		t.Fatal("debounce did not trigger after Touch")
+	}
+}
+
+func TestTouchResetsDelay(t *testing.T) {
+	t.Parallel()
+
+	d := New(30 * time.Millisecond)
+	d.Touch()
+	<-time.After(20 * time.Millisecond)
+	d.Touch()
+
+	select {
+	case <-d.Triggered():
+		t.Fatal("debounce triggered before the latest Touch delay elapsed")
+	case <-time.After(15 * time.Millisecond):
+	}
+
+	select {
+	case <-d.Triggered():
+	case <-time.After(80 * time.Millisecond):
+		t.Fatal("debounce did not trigger after the latest Touch")
+	}
+}


### PR DESCRIPTION
`ControlStream` starts waiting on `nsDebounce.Triggered()` right away. Before this fix, `Triggered()` armed the timer on first read, so an idle stream could send an empty namespaces update after 100ms even when no namespace event ever happened. Kinda noisy.

Fix is small:
- keep `debounce` idle until the first `Touch()`
- add tests for no pre-touch trigger, normal trigger, and reset-on-touch

Repro:
1. On `master`, run this in `backend`:
```sh
cat >/tmp/repro.go <<'EOF'
package main

import (
  "fmt"
  "time"

  "github.com/cilium/hubble-ui/backend/pkg/debounce"
)

func main() {
  d := debounce.New(50 * time.Millisecond)
  select {
  case <-d.Triggered():
    fmt.Println("triggered without touch")
  case <-time.After(120 * time.Millisecond):
    fmt.Println("no trigger")
  }
}
EOF
go run /tmp/repro.go
```
2. On `master` it prints `triggered without touch`.
3. With this branch it prints `no trigger`.
4. `go test ./...` still passes.
