### PR TITLE
ui: persist 'Hide remote node' and 'Hide prometheus app' filters across reloads

### DIFF
--- a/src/data-layer/common.ts
+++ b/src/data-layer/common.ts
@@ -12,6 +12,8 @@ export type Options = {
 export type StorageParameters = {
   isHostShown: boolean;
   isKubeDNSShown: boolean;
+  isRemoteNodeShown: boolean;
+  isPrometheusAppShown: boolean;
   isAggregationOff: boolean | null;
   dataMode: DataMode | null;
 };

--- a/src/data-layer/data-layer.ts
+++ b/src/data-layer/data-layer.ts
@@ -93,6 +93,8 @@ export class DataLayer extends EventEmitter<Handlers> {
     return {
       isHostShown: storage.getShowHost(),
       isKubeDNSShown: storage.getShowKubeDns(),
+      isRemoteNodeShown: storage.getShowRemoteNode(),
+      isPrometheusAppShown: storage.getShowPrometheusApp(),
       isAggregationOff: storage.getIsAggregationOff(),
       dataMode: storage.getDataMode(),
     };

--- a/src/ui-layer/ui-layer.ts
+++ b/src/ui-layer/ui-layer.ts
@@ -179,6 +179,8 @@ export class UILayer {
     // of the app.
     this.store.controls.setShowHost(storageParams.isHostShown);
     this.store.controls.setShowKubeDns(storageParams.isKubeDNSShown);
+    this.store.controls.setShowRemoteNode(storageParams.isRemoteNodeShown);
+    this.store.controls.setShowPrometheusApp(storageParams.isPrometheusAppShown);
     this.store.controls.setHttpStatus(routeParams.httpStatus);
     this.store.controls.setFlowFilters(routeParams.flowFilters);
     this.store.controls.setVerdicts(routeParams.verdicts);


### PR DESCRIPTION
The "Hide remote node" and "Hide prometheus app" visual filters are saved to localStorage when toggled, but their values are never read back at startup. As a result they reset to the default (hidden) on every page reload, while "Hide host service" and "Hide kube-dns:53 pod" persist correctly.

This adds the two missing flags to `StorageParameters`, reads them in `readLocalStorageParams()`, and restores them during initialization in `ui-layer.ts` — mirroring the existing host/kube-dns handling.
