### PR TITLE
enable-h2c-for-backend

### DIFF
--- a/backend/internal/apiserver/apiserver.go
+++ b/backend/internal/apiserver/apiserver.go
@@ -108,6 +108,11 @@ func (srv *APIServer) Listen() error {
 		handler = srv.handlerMiddleware(handler)
 	}
 
+	protocols := http.Protocols{}
+	protocols.SetHTTP1(true)
+	if srv.cfg.ServerEnableHTTP2Unencrypted {
+		protocols.SetUnencryptedHTTP2(true)
+	}
 	srv.instance = &http.Server{
 		Addr:    addr,
 		Handler: handler,
@@ -115,6 +120,7 @@ func (srv *APIServer) Listen() error {
 			return srv.baseContext
 		},
 		ReadHeaderTimeout: 5 * time.Second,
+		Protocols: &protocols,
 	}
 
 	srv.log.Info("running ListenAndServe", "port", port, "apipath", srv.rootRoute)

--- a/backend/internal/config/builder.go
+++ b/backend/internal/config/builder.go
@@ -205,6 +205,12 @@ func (b *ConfigBuilder) initWebServer(cfg *Config) error {
 	corsEnabled.LogIfFallback(b.logger)
 	cfg.CORSEnabled = corsEnabled.Value
 
+	serverEnableHTTP2Unencrypted := b.props.ServerEnableHTTP2Unencrypted()
+	if err := serverEnableHTTP2Unencrypted.Err(); err != nil {
+		return err
+	}
+	cfg.ServerEnableHTTP2Unencrypted = serverEnableHTTP2Unencrypted.Value
+
 	return nil
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	TLSRelayClientKeyFile  string
 
 	relayClientConfig certloader.ClientConfigBuilder
+
+	ServerEnableHTTP2Unencrypted bool
 }
 
 func New(log *slog.Logger, propGetters PropGetters) *ConfigBuilder {

--- a/backend/internal/config/prop_getters.go
+++ b/backend/internal/config/prop_getters.go
@@ -9,20 +9,21 @@ import (
 )
 
 type PropGetters struct {
-	GopsEnabled              EnvVarGetter[bool]
-	GopsPort                 EnvVarGetter[uint16]
-	CorsEnabled              EnvVarGetter[bool]
-	DebugLogs                EnvVarGetter[bool]
-	RelayAddr                EnvVarGetter[string]
-	UIServerPort             EnvVarGetter[uint16]
-	TLSToRelayEnabled        EnvVarGetter[bool]
-	TLSToRelayServerName     EnvVarGetter[string]
-	TLSToRelayCACertFiles    EnvVarGetter[string]
-	TLSToRelayClientCertFile EnvVarGetter[string]
-	TLSToRelayClientKeyFile  EnvVarGetter[string]
-	ClientPollDelays         []time.Duration
-	E2ETestModeEnabled       EnvVarGetter[bool]
-	E2ELogfilesBasepath      EnvVarGetter[string]
+	GopsEnabled                  EnvVarGetter[bool]
+	GopsPort                     EnvVarGetter[uint16]
+	CorsEnabled                  EnvVarGetter[bool]
+	DebugLogs                    EnvVarGetter[bool]
+	RelayAddr                    EnvVarGetter[string]
+	UIServerPort                 EnvVarGetter[uint16]
+	TLSToRelayEnabled            EnvVarGetter[bool]
+	TLSToRelayServerName         EnvVarGetter[string]
+	TLSToRelayCACertFiles        EnvVarGetter[string]
+	TLSToRelayClientCertFile     EnvVarGetter[string]
+	TLSToRelayClientKeyFile      EnvVarGetter[string]
+	ClientPollDelays             []time.Duration
+	E2ETestModeEnabled           EnvVarGetter[bool]
+	E2ELogfilesBasepath          EnvVarGetter[string]
+	ServerEnableHTTP2Unencrypted EnvVarGetter[bool]
 }
 
 type EnvVarGetter[T any] func() EnvVarResult[T]

--- a/backend/main.go
+++ b/backend/main.go
@@ -27,6 +27,7 @@ func main() {
 		TLSToRelayClientKeyFile:  config.StrOr("TLS_RELAY_CLIENT_KEY_FILE", ""),
 		E2ETestModeEnabled:       config.BoolOr("E2E_TEST_MODE", false),
 		E2ELogfilesBasepath:      config.StrOr("E2E_LOGFILES_BASEPATH", ""),
+		ServerEnableHTTP2Unencrypted: config.BoolOr("SERVER_ENABLE_HTTP2_UNENCRYPTED", false),
 	}).Build()
 
 	if err != nil {


### PR DESCRIPTION
Allows to enable unencrypted http2 for backend server