### PR TITLE
chore: bumped base version of nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG NODE_ENV=production
 RUN npm run build
 
 # skopeo inspect --override-os linux --override-arch amd64 docker://docker.io/nginxinc/nginx-unprivileged:1.29.8-alpine3.23-slim | jq -r '.Digest'
-FROM docker.io/nginxinc/nginx-unprivileged:1.29.8-alpine3.23-slim@sha256:f57d4c81491f04d5a9e6fe5609229b47ff440e769e3738a0476eda454281194e AS release
+FROM docker.io/nginxinc/nginx-unprivileged:1.31.3-alpine3.24-slim@sha256:22f839c5fb4007dc24d203a170a9e03fc185d660bfefc34ac6823a7aef085cbc AS release
 USER root
 RUN apk upgrade --no-cache
 USER 101


### PR DESCRIPTION
Bumped base version of Nginx to 1.31.3 on newer version of alpine linux.