### PR TITLE
Title world cards from their label, not a peer's DNS name

### DIFF
--- a/src/domain/service-map/__tests__/card.test.ts
+++ b/src/domain/service-map/__tests__/card.test.ts
@@ -1,0 +1,29 @@
+import { ServiceCard } from '~/domain/service-map';
+import { services } from '~/testing/data';
+
+describe('ServiceCard', () => {
+  describe('world card with DNS names', () => {
+    const card = ServiceCard.fromService({
+      ...services.worldIPv4,
+      identity: 9,
+      dnsNames: ['api.example.com', 'cdn.example.com'],
+    });
+
+    test('is captioned by its reserved label, not by a peer domain', () => {
+      expect(card.caption).toBe('world-ipv4');
+    });
+
+    // A world card stands for every external peer of its identity, so it must
+    // match all of their flows, not one peer's.
+    test('matches every flow of its identity', () => {
+      expect(card.filterEntries.find(e => e.isIdentity)?.query).toBe('9');
+    });
+
+    // Filter entries are OR'd, so a per-domain entry could only ever restate
+    // part of what the identity entry already matches -- while reading in the
+    // search bar as though the card were scoped to that one domain.
+    test('emits no DNS filter narrowing it to a single peer', () => {
+      expect(card.filterEntries.find(e => e.isDNS)).toBeUndefined();
+    });
+  });
+});

--- a/src/domain/service-map/card.ts
+++ b/src/domain/service-map/card.ts
@@ -132,10 +132,6 @@ export class ServiceCard extends AbstractCard {
       result.push(FilterEntry.newWorkload(this.workload));
     }
 
-    if (this.isDNS) {
-      result.push(FilterEntry.newDNS(this.caption));
-    }
-
     if (this.isIngress) {
       result.push(FilterEntry.newLabel(ReservedLabel.Ingress));
     }
@@ -208,10 +204,6 @@ export class ServiceCard extends AbstractCard {
 
   @computed
   public get caption(): string {
-    if (this.isWorld && this.domain) {
-      return this.domain;
-    }
-
     if (this.isIngress) return 'Ingress';
 
     return this.appName;


### PR DESCRIPTION
A world card holds every external peer sharing its identity. Captioning world cards with service.dnsNames[0] titles it after an arbitrary one domain.

With L7 DNS and cilium/cilium#48121 flows will retain their DNS name until terminated. More flows will have a DNS name most of the time. The current behaviour appears like all traffic is with dnsNames[0] only where it could be with multiple unrelated hosts.

Change so that world cards are titled after their label (world-ipv[46]) and clicking on a world card filters on its world-ipv[46] identity.

I also considered separate nodes per dnsName but this becomes very visually complex with more than a couple external hosts involved.