### PR TITLE
Fix white overlap box on active service map cards in Safari

### DIFF
--- a/src/components/ServiceMapCard/styles.scss
+++ b/src/components/ServiceMapCard/styles.scss
@@ -15,8 +15,8 @@
   &.active {
     cursor: grabbing;
     box-shadow: var(--hubble-ui-card-boxshadow-active);
-    opacity: 0.9;
-    transition-duration: 0;
+    background-color: var(--hubble-ui-svcmap-card-bg-primary-active);
+    transition-duration: 0s;
   }
 }
 

--- a/src/styles/common/themes.scss
+++ b/src/styles/common/themes.scss
@@ -91,6 +91,7 @@
 
   /* Service Map | Card */
   --hubble-ui-svcmap-card-bg-primary: rgb(251 251 251 / 85%);
+  --hubble-ui-svcmap-card-bg-primary-active: rgb(251 251 251 / 76.5%);
   --hubble-ui-svcmap-card-bg-secondary: #f6f6f6;
   --hubble-ui-svcmap-card-httpendpt-bg: #fff;
   --hubble-ui-svcmap-card-label-bg: #eaeaea;


### PR DESCRIPTION
Bake the active backplate's alpha into its background color instead of using `opacity`, which promoted it to its own compositing layer and made WebKit paint it over the card rather than under it.

Example of UI bug on Safari before this PR:

<img width="1066" height="807" alt="Screenshot 2026-08-21 at 19 11 01-safari-before" src="https://github.com/user-attachments/assets/055c2e82-91eb-4d1d-bae9-dfd7ec5b020d" />

After the fix Safari appears as expected, and Chrome appears unchanged.