### PR TITLE
Allow hubble-ui to filter on TCP flags

### DIFF
--- a/src/components/ServiceMapApp/index.tsx
+++ b/src/components/ServiceMapApp/index.tsx
@@ -156,7 +156,7 @@ export const ServiceMapApp = observer(function ServiceMapApp() {
       onVerdictChange={v => ui.controls.toggleVerdict(v)}
       selectedHttpStatus={store.controls.httpStatus}
       onHttpStatusChange={store.controls.setHttpStatus}
-      flowFilters={store.controls.filteredFlowFilters}
+      flowFilters={store.controls.flowFilters}
       onChangeFlowFilters={ff => ui.controls.setFlowFilters(ff)}
       showHost={ui.controls.isHostShown}
       onShowHostToggle={() => ui.controls.toggleShowHost()}

--- a/src/data-layer/controls.ts
+++ b/src/data-layer/controls.ts
@@ -261,9 +261,6 @@ export class Controls extends EventEmitter<Handlers> {
     const services = this.store.currentFrame.services;
 
     for (let filter of ff) {
-      // NOTE: Filtering by TCP flags is not supported?
-      if (filter.isTCPFlag) continue;
-
       const card = services.byFilterEntry(filter);
       if (card != null) {
         filter = filter.clone().setMeta(filter.meta || card.getFilterEntryMeta(filter) || '');

--- a/src/data-layer/service-map.ts
+++ b/src/data-layer/service-map.ts
@@ -244,7 +244,7 @@ export class ServiceMap extends EventEmitter<Handlers> {
     const [include, exclude] = !isActive ? [card.filterEntries, []] : [[], card.filterEntries];
 
     const [flowFilters, isChanged] = FilterEntry.combine(
-      this.store.controls.filteredFlowFilters,
+      this.store.controls.flowFilters,
       include,
       exclude,
     );

--- a/src/factories/proto/index.ts
+++ b/src/factories/proto/index.ts
@@ -6,6 +6,7 @@ import { EventParams, EventParamsSet } from '~/api/general/event-stream';
 import { ReservedLabel, SpecialLabel } from '~/domain/labels';
 import { Filters, FilterEntry, FilterKind } from '~/domain/filtering';
 import { CiliumEventTypes } from '~/domain/cilium';
+import { TCPFlagName } from '~/domain/hubble';
 import * as helpers from '~/domain/helpers';
 
 export class ProtoFactory {
@@ -293,6 +294,14 @@ export class ProtoFactory {
           fromInside.sourceWorkload.push(workload);
           break;
         }
+        case FilterKind.TCPFlag: {
+          const tcpFlags = ProtoFactory.tcpFlagsFromFilterEntry(filter);
+          if (tcpFlags == null) break;
+
+          toInside.tcpFlags.push(tcpFlags);
+          fromInside.tcpFlags.push(tcpFlags);
+          break;
+        }
       }
 
       wlFilters.push(toInside, fromInside);
@@ -347,12 +356,47 @@ export class ProtoFactory {
           fromInside.destinationWorkload.push(workload);
           break;
         }
+        case FilterKind.TCPFlag: {
+          const tcpFlags = ProtoFactory.tcpFlagsFromFilterEntry(filter);
+          if (tcpFlags == null) break;
+
+          toInside.tcpFlags.push(tcpFlags);
+          fromInside.tcpFlags.push(tcpFlags);
+          break;
+        }
       }
 
       wlFilters.push(fromInside, toInside);
     }
 
     return wlFilters;
+  }
+
+  // NOTE: protobuf-ts mangles the uppercase proto field names (FIN, SYN, ...)
+  // NOTE: into this form, so the mapping cannot be derived from the flag name.
+  private static readonly tcpFlagProtoFields: Record<TCPFlagName, keyof flowpb.TCPFlags> = {
+    fin: 'fIN',
+    syn: 'sYN',
+    rst: 'rST',
+    psh: 'pSH',
+    ack: 'aCK',
+    urg: 'uRG',
+    ece: 'eCE',
+    cwr: 'cWR',
+    ns: 'nS',
+  };
+
+  public static tcpFlagsFromFilterEntry(fe: FilterEntry): flowpb.TCPFlags | null {
+    if (!fe.isTCPFlag || !fe.query) return null;
+
+    const flag = fe.query.toLowerCase() as TCPFlagName;
+    const field = ProtoFactory.tcpFlagProtoFields[flag];
+    if (field == null) return null;
+
+    const tcpFlags = flowpb.TCPFlags.create();
+    tcpFlags[field] = true;
+
+    return tcpFlags;
   }
 
   public static workloadFromFilterEntry(fe: FilterEntry): flowpb.Workload | null {

--- a/src/store/stores/controls.ts
+++ b/src/store/stores/controls.ts
@@ -142,7 +142,7 @@ export class ControlStore {
   }
 
   public areSomeFilterEntriesEnabled(filterEntries: FilterEntry[]): boolean {
-    const currentKeys = new Set(this.filteredFlowFilters.map(fe => fe.toString()));
+    const currentKeys = new Set(this.flowFilters.map(fe => fe.toString()));
 
     for (const fe of filterEntries) {
       const key = fe.toString();
@@ -151,10 +151,6 @@ export class ControlStore {
     }
 
     return false;
-  }
-
-  public get filteredFlowFilters() {
-    return this.flowFilters.filter(f => !f.isTCPFlag);
   }
 
   public get activeVerdict(): Verdict | null {


### PR DESCRIPTION
User interface and backend support was already present for filtering on TCP flags but the code disabled it with this comment:

  // NOTE: Filtering by TCP flags is not supported?

Looking back it appears TCP flag filtering would have been available at the time of that commit.

AI level 4: AI wrote the change, and I tested it myself with my own queries.