### PR TITLE
numbers: fix numberWithCommas for negative numbers

### DIFF
--- a/src/utils/__tests__/numberWithCommas.test.ts
+++ b/src/utils/__tests__/numberWithCommas.test.ts
@@ -1,0 +1,15 @@
+import { numberWithCommas } from '../numbers';
+
+describe('numberWithCommas', () => {
+  test.each([
+    [123, '123'],
+    [1234, '1,234'],
+    [123456, '123,456'],
+    [-123, '-123'],
+    [-1234, '-1,234'],
+    [-123456, '-123,456'],
+    [-123456789, '-123,456,789'],
+  ])('%p -> %p', (input, expected) => {
+    expect(numberWithCommas(input)).toBe(expected);
+  });
+});

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,15 +1,17 @@
 export const numberWithCommas = (x: string | number): string => {
   const str = x.toString();
-  const len = str.length;
+  const isNegative = str.startsWith('-');
+  const digits = isNegative ? str.slice(1) : str;
+  const len = digits.length;
   const commaIndex = len % 3;
   let formatted = '';
   for (let i = 0; i < len; i++) {
     if (i > 0 && i % 3 === commaIndex) {
       formatted += ',';
     }
-    formatted += str[i];
+    formatted += digits[i];
   }
-  return formatted;
+  return (isNegative ? '-' : '') + formatted;
 };
 
 export enum Units {


### PR DESCRIPTION
## Why

`numberWithCommas` computed the comma grouping index from the full string including the leading `-` for negative numbers, which throws off the grouping whenever the digit count (excluding sign) is a multiple of 3. `numberWithCommas(-123456)` returned `"-,123,456"` instead of `"-123,456"`.

## What changed

Compute the comma index from the digit count excluding the sign. Added `src/utils/__tests__/numberWithCommas.test.ts`, since the function had no test coverage at all before this.

## Testing

`npx jest numberWithCommas`: 7/7 pass.
